### PR TITLE
Update Explosives.xml

### DIFF
--- a/Data-1.13/TableData/Items/Explosives.xml
+++ b/Data-1.13/TableData/Items/Explosives.xml
@@ -1981,7 +1981,7 @@
 		<ubHorizontalDegree>0</ubHorizontalDegree>
 		<ubVerticalDegree>0</ubVerticalDegree>
 	</EXPLOSIVE>
-	<EXPLOSIVE><!-- roof collapse-->		<!-- Pr0ph3t: <ubType>12 is FIRE RETARDANT, Setting to <ubType>11 for DEBRIS SMOKE, Jan 15 2023 -->
+	<EXPLOSIVE><!-- roof collapse-->
 		<uiIndex>99</uiIndex>
 		<ubType>11</ubType>
 		<ubDamage>0</ubDamage>

--- a/Data-1.13/TableData/Items/Explosives.xml
+++ b/Data-1.13/TableData/Items/Explosives.xml
@@ -1981,9 +1981,9 @@
 		<ubHorizontalDegree>0</ubHorizontalDegree>
 		<ubVerticalDegree>0</ubVerticalDegree>
 	</EXPLOSIVE>
-	<EXPLOSIVE><!-- roof collapse-->
+	<EXPLOSIVE><!-- roof collapse-->		<!-- Pr0ph3t: <ubType>12 is FIRE RETARDANT, Setting to <ubType>11 for DEBRIS SMOKE, Jan 15 2023 -->
 		<uiIndex>99</uiIndex>
-		<ubType>12</ubType>
+		<ubType>11</ubType>
 		<ubDamage>0</ubDamage>
 		<ubStunDamage>0</ubStunDamage>
 		<ubRadius>0</ubRadius>


### PR DESCRIPTION
Pr0ph3t: <ubType>12 is FIRE RETARDANT, Setting to <ubType>11 for DEBRIS SMOKE, Jan 15 2023

This corrects issue:

https://github.com/1dot13/gamedir/issues/15

(FIX: Roof collapses producing white smoke due to erronous Explosion Type)