### PR TITLE
Use better default shader

### DIFF
--- a/ddraw.ini
+++ b/ddraw.ini
@@ -36,7 +36,7 @@ adjmouse=true
 
 ; Preliminary libretro shader support - (Requires 'renderer=opengl') https://github.com/libretro/glsl-shaders
 ; 2x scaling example: https://imgur.com/a/kxsM1oY - 4x scaling example: https://imgur.com/a/wjrhpFV
-shader=Shaders\nearest-neighbor.glsl
+shader=Shaders\cubic\catmull-rom-bilinear.glsl
 
 ; Window position, -32000 = center to screen
 posX=-32000


### PR DESCRIPTION
catmull-rom-bilinear.glsl is a better choice as default setting, nearest-neighbor.glsl does only look good with integer-scaling  (There were multiple complaints on discord about this issue)