### PR TITLE
fix invalid  GridNo Maria/Angel BH-quest

### DIFF
--- a/Data-1.13/Scripts/strategicmap.lua
+++ b/Data-1.13/Scripts/strategicmap.lua
@@ -657,9 +657,16 @@ function HandleSectorTacticalEntry( sSectorX, sSectorY, bSectorZ, fHasEverBeenPl
 				CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			13032, hostile)
 				CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			19291, hostile)
 				
-				-- dont spawn in deep water
+				-- dont spawn in deep water (B14) 
 				if (sSectorX == 14 and sSectorY == 2) then
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			16533, hostile)
+				-- dont spawn in bush (B2) 
+				elseif 	(sSectorX == 8 and sSectorY == 2) then
+				    CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13239, hostile)
+				-- dont spawn in cornfield (B12)
+				elseif 	(sSectorX == 12 and sSectorY == 2) then
+				    CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13860, hostile)
+				-- spawn at common GridNo in all other possible sectors
 				else
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13557, hostile)
 				end
@@ -677,9 +684,16 @@ function HandleSectorTacticalEntry( sSectorX, sSectorY, bSectorZ, fHasEverBeenPl
 				CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			13032, hostile)
 				CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			19291, hostile)
 				
-				-- dont spawn in deep water
+				-- dont spawn in deep water (B14) 
 				if (sSectorX == 14 and sSectorY == 2) then
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			16533, hostile)
+				-- dont spawn in bush (B2) 
+				elseif 	(sSectorX == 8 and sSectorY == 2) then
+				    CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13239, hostile)
+				-- dont spawn in cornfield (B12)
+				elseif 	(sSectorX == 12 and sSectorY == 2) then
+				    CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13860, hostile)
+				-- spawn at common GridNo in all other possible sectors		
 				else
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13557, hostile)
 				end


### PR DESCRIPTION
maria/angel bountyhunter quest

- the common used GridNo for one bountyhunter was invalid in some of the possible sectors
- this had been already addressed for B14 in original commit
- now expanded to use altenate GridNo in B2 and B12 as well
- checked in MapEditor, other possible sectors allow a valid spawn at common used GridNo