### PR TITLE
Specific addictions and facility drug risks

### DIFF
--- a/Data-1.13/TableData/Backgrounds.xml
+++ b/Data-1.13/TableData/Backgrounds.xml
@@ -103,6 +103,14 @@
 
 		<!-- on/off properties: 1 for on, 0 for off -->		  
 		<druguse>0</druguse>			<!-- might use drugs from inventory (the 'Larry'-behaviour) -->
+		<drugtypes>						<!-- optional tags specifying drug types relevant for druguse tag, if none specified all drug types will be viable -->
+			<drugtype>0</drugtype>
+			<drugtype>0</drugtype>
+		</drugtypes>
+		<drugitems>						<!-- optional tags specifying items relevant for druguse tag, if none specified all drug items will be viable -->
+			<drugitem>0</drugitem>
+			<drugitem>0</drugitem>
+		</drugitems>
 		<xenophobic>0</xenophobic>		<!-- lower opinion of everybody without this background -->
 		<level_underground>0</level_underground>  <!-- +1 effective level if underground -->
 		<scrounging>0</scrounging>		<!-- might steal money from the locals (chance to anger locals) -->

--- a/Data-1.13/TableData/Map/FacilityTypes.xml
+++ b/Data-1.13/TableData/Map/FacilityTypes.xml
@@ -44,6 +44,11 @@
 				<ubChance>500</ubChance>
 				<bBaseEffect>1</bBaseEffect>
 				<ubRange>0</ubRange>
+				<drugitems>
+					<drugitem>245</drugitem>
+					<drugitem>255</drugitem>
+					<drugitem>256</drugitem>
+				</drugitems>
 			</DRUNK>
 		</ASSIGNMENT>
 		<ASSIGNMENT>

--- a/Data-UB/TableData/Map/FacilityTypes.xml
+++ b/Data-UB/TableData/Map/FacilityTypes.xml
@@ -44,6 +44,11 @@
 				<ubChance>500</ubChance>
 				<bBaseEffect>1</bBaseEffect>
 				<ubRange>0</ubRange>
+				<drugitems>
+					<drugitem>245</drugitem>
+					<drugitem>255</drugitem>
+					<drugitem>256</drugitem>
+				</drugitems>
 			</DRUNK>
 		</ASSIGNMENT>
 	</FACILITYTYPE>

--- a/Data/TableData/Backgrounds.xml
+++ b/Data/TableData/Backgrounds.xml
@@ -103,6 +103,14 @@
 
 		<!-- on/off properties: 1 for on, 0 for off -->		  
 		<druguse>0</druguse>			<!-- might use drugs from inventory (the 'Larry'-behaviour) -->
+		<drugtypes>						<!-- optional tags specifying drug types relevant for druguse tag, if none specified all drug types will be viable -->
+			<drugtype>0</drugtype>
+			<drugtype>0</drugtype>
+		</drugtypes>
+		<drugitems>						<!-- optional tags specifying items relevant for druguse tag, if none specified all drug items will be viable -->
+			<drugitem>0</drugitem>
+			<drugitem>0</drugitem>
+		</drugitems>
 		<xenophobic>0</xenophobic>		<!-- lower opinion of everybody without this background -->
 		<level_underground>0</level_underground>  <!-- +1 effective level if underground -->
 		<scrounging>0</scrounging>		<!-- might steal items (and put them in personal inventory) -->

--- a/Data/TableData/Map/Facilities.xml
+++ b/Data/TableData/Map/Facilities.xml
@@ -21,6 +21,11 @@
 		<ubHidden>2</ubHidden>
 	</FACILITY>	
 	<FACILITY>
+		<SectorGrid>C13</SectorGrid>
+		<FacilityType>2</FacilityType>
+		<ubHidden>2</ubHidden>
+	</FACILITY>
+	<FACILITY>
 		<SectorGrid>D13</SectorGrid>
 		<FacilityType>1</FacilityType>
 		<ubHidden>2</ubHidden>
@@ -50,6 +55,23 @@
 	<FACILITY>
 		<SectorGrid>I14</SectorGrid>
 		<FacilityType>1</FacilityType>
+		<ubHidden>2</ubHidden>
+	</FACILITY>
+	
+	<!-- SAN MONA -->
+	<FACILITY>
+		<SectorGrid>C5</SectorGrid>
+		<FacilityType>2</FacilityType>
+		<ubHidden>2</ubHidden>
+	</FACILITY>
+	<FACILITY>
+		<SectorGrid>C6</SectorGrid>
+		<FacilityType>2</FacilityType>
+		<ubHidden>2</ubHidden>
+	</FACILITY>
+	<FACILITY>
+		<SectorGrid>D5</SectorGrid>
+		<FacilityType>2</FacilityType>
 		<ubHidden>2</ubHidden>
 	</FACILITY>
 	
@@ -92,6 +114,11 @@
 		<ubHidden>2</ubHidden>
 	</FACILITY>	
 	<FACILITY>
+		<SectorGrid>G9</SectorGrid>
+		<FacilityType>2</FacilityType>
+		<ubHidden>2</ubHidden>
+	</FACILITY>
+	<FACILITY>
 		<SectorGrid>H8</SectorGrid>
 		<FacilityType>1</FacilityType>
 		<ubHidden>2</ubHidden>
@@ -122,7 +149,12 @@
 		<SectorGrid>H2</SectorGrid>
 		<FacilityType>1</FacilityType>
 		<ubHidden>2</ubHidden>
-	</FACILITY>			
+	</FACILITY>	
+	<FACILITY>
+		<SectorGrid>H2</SectorGrid>
+		<FacilityType>2</FacilityType>
+		<ubHidden>2</ubHidden>
+	</FACILITY>	
 	<FACILITY>
 		<SectorGrid>H3</SectorGrid>
 		<FacilityType>1</FacilityType>

--- a/Data/TableData/Map/FacilityTypes.xml
+++ b/Data/TableData/Map/FacilityTypes.xml
@@ -6,4 +6,20 @@
 		<ubTotalStaffLimit>0</ubTotalStaffLimit>
 		<ubMilitiaTrainersAllowed>2</ubMilitiaTrainersAllowed>
 	</FACILITYTYPE>
+	<FACILITYTYPE>
+		<ubIndex>2</ubIndex>
+		<szFacilityName>Small Sleazy Bar</szFacilityName>
+		<szFacilityShortName>Bar</szFacilityShortName>
+		<ubTotalStaffLimit>0</ubTotalStaffLimit>
+		<ASSIGNMENT>
+			<ubAssignmentType>REST</ubAssignmentType>
+			<szTooltipText></szTooltipText>
+			<ubStaffLimit>1</ubStaffLimit>
+			<DRUNK>
+				<ubChance>1</ubChance>
+				<bBaseEffect>0</bBaseEffect>
+				<ubRange>0</ubRange>
+			</DRUNK>
+		</ASSIGNMENT>
+	</FACILITYTYPE>
 </FACILITYTYPES>


### PR DESCRIPTION
Game dir changes for https://github.com/1dot13/source/pull/226
Set hidden bar facilities for vanilla sectors in place of hardcoded bar sectors.
Set `<drugitems>` for sleazy bars (alcohol/beer/wine will be randomly selected).
Added `<drugtypes>` and `<drugitems>` to backgrounds (template only).