### PR TITLE
[Fix] missing attachment for G36C

### DIFF
--- a/Data-1.13/TableData/Items/Attachments.xml
+++ b/Data-1.13/TableData/Items/Attachments.xml
@@ -26008,6 +26008,11 @@
 		<APCost>20</APCost>
 	</ATTACHMENT>
 	<ATTACHMENT>
+		<attachmentIndex>1322</attachmentIndex>  
+		<itemIndex>664</itemIndex>
+		<APCost>20</APCost>
+	</ATTACHMENT>
+	<ATTACHMENT>
 		<attachmentIndex>1322</attachmentIndex>
 		<itemIndex>726</itemIndex>
 		<APCost>20</APCost>


### PR DESCRIPTION
item 664, the G36C, has two default attachments defined in items.xml (1746, Folding Stock and 1322, in-build 2x Scope)

It missed 1322 in attachments.xml and  when using the Folding Stock (fold/unfold) it resulted in an error for not finding 1322 attached after the transformation

Added entry for 1322 (in-build 2x Scope) on 664 (G36C) in attachments.xml to fix that