### PR TITLE
Fix for two wrong default attachments

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -19448,7 +19448,6 @@
 		<BR_NewInventory>3</BR_NewInventory>
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<BR_ROF>750</BR_ROF>
-		<DefaultAttachment>1322</DefaultAttachment>
 		<DefaultAttachment>1746</DefaultAttachment>
 		<usOverheatingCooldownFactor>100.0</usOverheatingCooldownFactor>
 		<DamageChance>10</DamageChance>
@@ -22907,7 +22906,7 @@
 		<BR_ROF>750</BR_ROF>
 		<AimBonus>10</AimBonus>
 		<MinRangeForAimBonus>20</MinRangeForAimBonus>
-		<DefaultAttachment>1749</DefaultAttachment>
+		<DefaultAttachment>1746</DefaultAttachment>
 		<PercentAPReduction>20</PercentAPReduction>
 		<VisionRangeBonus>25</VisionRangeBonus>
 		<PercentTunnelVision>20</PercentTunnelVision>


### PR DESCRIPTION
Removed the built-in 2x scope from the G36C (only has iron sights and a picatinny rail in reality) and replaced the built-in retractable stock on the G36K with a folding stock.