### PR TITLE
Adjusted attachments.xml for G36C

### DIFF
--- a/Data-1.13/TableData/Items/Attachments.xml
+++ b/Data-1.13/TableData/Items/Attachments.xml
@@ -26008,11 +26008,6 @@
 		<APCost>20</APCost>
 	</ATTACHMENT>
 	<ATTACHMENT>
-		<attachmentIndex>1322</attachmentIndex>  
-		<itemIndex>664</itemIndex>
-		<APCost>20</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
 		<attachmentIndex>1322</attachmentIndex>
 		<itemIndex>726</itemIndex>
 		<APCost>20</APCost>


### PR DESCRIPTION
previous change removed the default in-build 2xscope from G36C in items.xml

to avoid assertion error, adjusted attachments.xml to refelct the change in there as well