### PR TITLE
Update StructureConstruct.xml

### DIFF
--- a/Data-1.13/TableData/Items/StructureConstruct.xml
+++ b/Data-1.13/TableData/Items/StructureConstruct.xml
@@ -21,7 +21,7 @@
 		<szTileSetDisplayName>Concertina wire</szTileSetDisplayName>
 		<szTileSetName>spot_1.sti</szTileSetName>
 		<dCreationCost>1.0</dCreationCost>
-		<fFortifyAdjacentAdjustment>1</fFortifyAdjacentAdjustment>
+		<fFortifyAdjacentAdjustment>0</fFortifyAdjacentAdjustment>  <!--recommended to be 0 for concertina wire-->
 		<northfacingtile>3</northfacingtile>
 		<northfacingtile>5</northfacingtile>
 		<southfacingtile>3</southfacingtile>


### PR DESCRIPTION
the tag fFortifyAdjacentAdjustment doesn't mesh well with how actual graphics for concertina look like and are sorted in .sti-file

that resulted in concertina being shown facing wrong direction when using fortification assignment and placing them next to each other

which was caused by that attempt to align to adjacent tile

setting the tag to 0 instead of 1 solved the issue

