### PR TITLE
Adjusted item coolness

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -51309,7 +51309,7 @@
 		<ubPerPocket>1</ubPerPocket>
 		<ItemSize>10</ItemSize>
 		<usPrice>1</usPrice>
-		<ubCoolness>3</ubCoolness>
+		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<WaterDamages>1</WaterDamages>
 		<Sinks>1</Sinks>
@@ -51342,7 +51342,7 @@
 		<ubPerPocket>1</ubPerPocket>
 		<ItemSize>10</ItemSize>
 		<usPrice>1</usPrice>
-		<ubCoolness>3</ubCoolness>
+		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<WaterDamages>1</WaterDamages>
 		<Sinks>1</Sinks>
@@ -52666,7 +52666,7 @@
 		<ubPerPocket>4</ubPerPocket>
 		<ItemSize>16</ItemSize>
 		<usPrice>80</usPrice>
-		<ubCoolness>3</ubCoolness>
+		<ubCoolness>2</ubCoolness>
 		<Medical>1</Medical>
 		<BR_NewInventory>6</BR_NewInventory>
 		<usOverheatingCooldownFactor>100.0</usOverheatingCooldownFactor>
@@ -52808,7 +52808,7 @@
 		<ubPerPocket>1</ubPerPocket>
 		<ItemSize>11</ItemSize>
 		<usPrice>20</usPrice>
-		<ubCoolness>3</ubCoolness>
+		<ubCoolness>1</ubCoolness>
 		<Medical>1</Medical>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>
@@ -52834,7 +52834,7 @@
 		<ubPerPocket>1</ubPerPocket>
 		<ItemSize>11</ItemSize>
 		<usPrice>25</usPrice>
-		<ubCoolness>4</ubCoolness>
+		<ubCoolness>3</ubCoolness>
 		<Medical>1</Medical>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>

--- a/Data-1.13/TableData/NPCInventory/AdditionalDealer_43_Inventory.xml
+++ b/Data-1.13/TableData/NPCInventory/AdditionalDealer_43_Inventory.xml
@@ -213,7 +213,7 @@
 		<ubOptimalNumber>3</ubOptimalNumber>
 	</INVENTORY>
 	<INVENTORY>
-		<uiIndex>41</uiIndex>
+		<uiIndex>42</uiIndex>
 		<sItemIndex>1715</sItemIndex>
 		<ubOptimalNumber>1</ubOptimalNumber>
 	</INVENTORY>


### PR DESCRIPTION
Adjusted item coolness
- surgical mask and gloves lowered coolness
- medical splint lowered coolness
- empty PPE-Bag lowered coolness
- full PPE-Bag lowered coolness 
reasoning: those are semi-essential for disease feature, therefore it's important to have the option to get them soon. 
and since all those are rather common items in the real world, that's reasonable enough
Typo Fix
- typo fix in merchant inventory