### PR TITLE
Reworked foodsystem exclusive items

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -213,6 +213,7 @@
 		<RobotUtilitySkillGrant>0</RobotUtilitySkillGrant>
 		<TransportGroupMinProgress>0</TransportGroupMinProgress>
 		<TransportGroupMaxProgress>0</TransportGroupMaxProgress>
+		<FoodSystemExclusive>0</FoodSystemExclusive>
 		<STAND_MODIFIERS>
 			<FlatBase>0</FlatBase>
 			<PercentBase>0</PercentBase>
@@ -46820,6 +46821,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>3</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>5</FoodType>
 		<usPortionSize>20</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46845,6 +46847,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>25</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>6</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46870,6 +46873,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>20</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>7</FoodType>
 		<usPortionSize>50</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46894,6 +46898,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>8</FoodType>
 		<usPortionSize>10</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46918,6 +46923,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>9</FoodType>
 		<usPortionSize>15</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46942,6 +46948,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>10</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46966,6 +46973,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>11</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -46990,6 +46998,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>12</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47014,6 +47023,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>13</FoodType>
 		<usPortionSize>13</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47039,6 +47049,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>15</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>14</FoodType>
 		<usPortionSize>50</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47064,6 +47075,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>15</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>15</FoodType>
 		<usPortionSize>50</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47089,6 +47101,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>18</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>16</FoodType>
 		<usPortionSize>50</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47114,6 +47127,7 @@
 		<Damageable>1</Damageable>
 		<BR_NewInventory>7</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>17</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47138,6 +47152,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>18</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47162,6 +47177,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>19</FoodType>
 		<usPortionSize>50</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47186,6 +47202,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>20</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47210,6 +47227,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>21</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47234,6 +47252,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>22</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47258,6 +47277,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>23</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47282,6 +47302,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>24</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47306,6 +47327,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>25</FoodType>
 		<usPortionSize>100</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47331,6 +47353,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>26</FoodType>
 		<usPortionSize>10</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47356,6 +47379,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>27</FoodType>
 		<usPortionSize>10</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47380,6 +47404,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>28</FoodType>
 		<usPortionSize>20</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47404,6 +47429,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>29</FoodType>
 		<usPortionSize>50</usPortionSize>
 		<STAND_MODIFIERS />
@@ -47773,6 +47799,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>37</FoodType>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
@@ -47796,6 +47823,7 @@
 		<ubCoolness>1</ubCoolness>
 		<Damageable>1</Damageable>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<FoodSystemExclusive>1</FoodSystemExclusive>
 		<FoodType>38</FoodType>
 		<usPortionSize>8</usPortionSize>
 		<STAND_MODIFIERS />
@@ -52808,7 +52836,7 @@
 		<ubPerPocket>1</ubPerPocket>
 		<ItemSize>11</ItemSize>
 		<usPrice>20</usPrice>
-		<ubCoolness>1</ubCoolness>
+		<ubCoolness>2</ubCoolness>
 		<Medical>1</Medical>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>


### PR DESCRIPTION
no food items if the food system is off
whether the item is exclusive is defined by tag in items.xml 
replaced previous way of decision, which used Item[usItemIndex].foodtype > 0 as criteria 
that also restricted dual use items (i.e. drugs that also have a foodtype, like coffee, etc.)