### PR TITLE
More consistent naming conventions LBE

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -33843,10 +33843,10 @@
 	<ITEM>
 		<uiIndex>1079</uiIndex>
 		<szItemName>TAC-1A Vest</szItemName>
-		<szLongItemName>TT Assault Vest</szLongItemName>
+		<szLongItemName>TT TAC-1A Assault Vest</szLongItemName>
 		<szItemDesc>A vest designed for carrying some of the most important consumables on a battlefield: ammo.</szItemDesc>
 		<szBRName>TT Assault Vest</szBRName>
-		<szBRDesc>The Tactical Tailor Assault Vest is for primary combat soldiers and can carry 12 AR magazines, or whatever other ammo type you need.</szBRDesc>
+		<szBRDesc>The Tactical Tailor Assault Vest (TAC-1A) is for primary combat soldiers and can carry 12 AR magazines, or whatever other ammo type you need.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<ubClassIndex>4</ubClassIndex>
@@ -34082,10 +34082,10 @@
 	<ITEM>
 		<uiIndex>1089</uiIndex>
 		<szItemName>TAC-1B Vest</szItemName>
-		<szLongItemName>TT Utility Vest</szLongItemName>
+		<szLongItemName>TT TAC-1B Utility Vest</szLongItemName>
 		<szItemDesc>A vest with two larger pockets for carrying big things.</szItemDesc>
 		<szBRName>TT Utility Vest</szBRName>
-		<szBRDesc>The Tactical Tailor utility vest is for those who primarily aren't combat soldiers, but have other duties as well.</szBRDesc>
+		<szBRDesc>The Tactical Tailor Utility Vest (TAC-1B) is for those who primarily aren't combat soldiers, but have other duties as well.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<ubClassIndex>14</ubClassIndex>
@@ -36882,9 +36882,9 @@
 	<ITEM>
 		<uiIndex>1170</uiIndex>
 		<szItemName>AR-Gren.</szItemName>
-		<szLongItemName>AR-Mag / Grenade Pouch</szLongItemName>
+		<szLongItemName>AR-Mag / Grenade Rig</szLongItemName>
 		<szItemDesc>A combination of a double AR-Mag pouch with three grenade pouches.</szItemDesc>
-		<szBRName>AR-Mag / Grenade Pouch</szBRName>
+		<szBRName>AR-Mag / Grenade Rig</szBRName>
 		<szBRDesc>This leg rig mounts a double AR-magazine pouch and three individual grenade pouches. Great for your primary combat soldiers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -36905,9 +36905,9 @@
 	<ITEM>
 		<uiIndex>1171</uiIndex>
 		<szItemName>AR-Util.</szItemName>
-		<szLongItemName>AR-Mag / Utility Pouch</szLongItemName>
+		<szLongItemName>AR-Mag / Utility Rig</szLongItemName>
 		<szItemDesc>A combination of a double AR-Mag pouch and a utility pouch.</szItemDesc>
-		<szBRName>AR-Mag / Utility Pouch</szBRName>
+		<szBRName>AR-Mag / Utility Rig</szBRName>
 		<szBRDesc>A double AR-magazine pouch and a larger utility pouch mounted together on a leg rig. This is useful for carrying larger things like explosives.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -36928,9 +36928,9 @@
 	<ITEM>
 		<uiIndex>1172</uiIndex>
 		<szItemName>Cant.-Util.</szItemName>
-		<szLongItemName>Canteen / Utility Pouch</szLongItemName>
-		<szItemDesc>Here a utility pouch was combined with a canteen pouch.</szItemDesc>
-		<szBRName>Canteen / Utility Pouch</szBRName>
+		<szLongItemName>Canteen / Utility Rig</szLongItemName>
+		<szItemDesc>Here a utility pouch was combined with a canteen pouch mounted together on a leg rig .</szItemDesc>
+		<szBRName>Canteen / Utility Rig</szBRName>
 		<szBRDesc>This leg rig has a utility pouch mounted beside a canteen pouch.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -36951,10 +36951,10 @@
 	<ITEM>
 		<uiIndex>1173</uiIndex>
 		<szItemName>Util.-Gren.</szItemName>
-		<szLongItemName>Utility / Grenade Pouch</szLongItemName>
-		<szItemDesc>A combination of a utility pouch, with three grenade pouches.</szItemDesc>
-		<szBRName>Utility / Grenade Pouch</szBRName>
-		<szBRDesc>Here we have a utility pouch, combined with three individual grenade pouches.</szBRDesc>
+		<szLongItemName>Utility / Grenade Rig</szLongItemName>
+		<szItemDesc>A combination of a utility pouch, with three grenade pouches mounted together on a leg rig.</szItemDesc>
+		<szBRName>Utility / Grenade Rig</szBRName>
+		<szBRDesc>Here we have a utility pouch, combined with three individual grenade pouches mounted together on a leg rig.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ItemFlag>2147483648</ItemFlag>
@@ -36975,9 +36975,9 @@
 	<ITEM>
 		<uiIndex>1174</uiIndex>
 		<szItemName>L.Mag-Util.</szItemName>
-		<szLongItemName>Large Mag / Utility Pouch</szLongItemName>
-		<szItemDesc>This combo has a utility pouch with two pouches for oddly shaped magazines.</szItemDesc>
-		<szBRName>Large Mag / Utility Pouch</szBRName>
+		<szLongItemName>Large Mag / Utility Rig</szLongItemName>
+		<szItemDesc>This combo has a utility pouch with two pouches for oddly shaped magazines mounted on a leg rig</szItemDesc>
+		<szBRName>Large Mag / Utility Rig</szBRName>
 		<szBRDesc>This leg rig offers a utility pouch with two large mag pouches for those extremely long P90 or G11 magazines (or similar odd magazines).</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -36999,7 +36999,7 @@
 		<uiIndex>1175</uiIndex>
 		<szItemName>L.Mag-Gren.</szItemName>
 		<szLongItemName>Large Mag / Grenade Pouch</szLongItemName>
-		<szItemDesc>A combination of two large magazine pouches and two grenade pouches.</szItemDesc>
+		<szItemDesc>A combination of two large magazine pouches and two grenade pouches mounted together on a leg rig.</szItemDesc>
 		<szBRName>Large Mag / Grenade Pouch</szBRName>
 		<szBRDesc>This leg rig mounts two large magazine pouches, combined with two individual grenade pouches.</szBRDesc>
 		<usItemClass>131072</usItemClass>
@@ -37733,10 +37733,10 @@
 	<ITEM>
 		<uiIndex>1196</uiIndex>
 		<szItemName>TAC-1E Vest</szItemName>
-		<szLongItemName>TT Pistol Vest</szLongItemName>
+		<szLongItemName>TT TAC-1E Pistol Vest</szLongItemName>
 		<szItemDesc>This vest has a pistol holster incorporated.</szItemDesc>
 		<szBRName>TT Pistol Vest</szBRName>
-		<szBRDesc>The Tactical Tailor 1E Vest is useful if your legs already carry some rigs, but you still want to pack a pistol. The holster on this vest will fit most standard pistols.</szBRDesc>
+		<szBRDesc>The Tactical Tailor Pistol Vest (TAC-1E) is useful if your legs already carry some rigs, but you still want to pack a pistol. The holster on this vest will fit most standard pistols.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<ubClassIndex>32</ubClassIndex>
@@ -37955,9 +37955,9 @@
 		<uiIndex>1203</uiIndex>
 		<szItemName>LRAK</szItemName>
 		<szLongItemName>LRAK SAW-Vest</szLongItemName>
-		<szItemDesc>This vest can take 4 ammobelts for your machinegun, or several drums.</szItemDesc>
+		<szItemDesc>This vest can take 4 ammobelts for your machinegun, or several drums. Allows to belt feed weapons directly from vest, if weapon is capable of such.</szItemDesc>
 		<szBRName>LRAK SAW-Vest</szBRName>
-		<szBRDesc>Your machine gunner will love this vest, provided he's strong enough to wear it when it is filled to capacity.</szBRDesc>
+		<szBRDesc>Your machine gunner will love this vest, provided he's strong enough to wear it when it is filled to capacity. Allows to belt feed weapons directly from vest, if weapon is capable of such.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<ubClassIndex>34</ubClassIndex>
@@ -38001,11 +38001,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1205</uiIndex>
-		<szItemName>Med. Pouch</szItemName>
-		<szLongItemName>Medical Pouch</szLongItemName>
+		<szItemName>Med. Rig</szItemName>
+		<szLongItemName>Medical Rig</szLongItemName>
 		<szItemDesc>This leg rig has a first aid pouch with several small belt loops, for the neat storage of syringes, and also carries a canteen.</szItemDesc>
 		<szBRName>Medical Pouch</szBRName>
-		<szBRDesc>Great for storing a first aid kit with additional syringes of whatever stimulants your troops need. Also keeps a canteen handy.</szBRDesc>
+		<szBRDesc>This leg rig is great for storing a first aid kit with additional syringes of whatever stimulants your troops need. Also keeps a canteen handy.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ubClassIndex>36</ubClassIndex>
@@ -38025,10 +38025,10 @@
 	<ITEM>
 		<uiIndex>1206</uiIndex>
 		<szItemName>Cant.-Gren.</szItemName>
-		<szLongItemName>Canteen / Grenade Pouch</szLongItemName>
-		<szItemDesc>A leg panel with a canteen pouch and three grenade pouches</szItemDesc>
-		<szBRName>Canteen / Grenade Pouch</szBRName>
-		<szBRDesc>This panel is equipped with a canteen pouch and three grenade pouches.</szBRDesc>
+		<szLongItemName>Canteen / Grenade Rig</szLongItemName>
+		<szItemDesc>A leg rig with a canteen pouch and three grenade pouches</szItemDesc>
+		<szBRName>Canteen / Grenade Rig</szBRName>
+		<szBRDesc>This leg rig is equipped with a canteen pouch and three grenade pouches.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ItemFlag>2147483648</ItemFlag>
@@ -38049,10 +38049,10 @@
 	<ITEM>
 		<uiIndex>1207</uiIndex>
 		<szItemName>AR-Ca.-Gr.</szItemName>
-		<szLongItemName>AR-Mag. / Canteen / Grenade Panel</szLongItemName>
+		<szLongItemName>AR-Mag. / Canteen / Grenade Rig</szLongItemName>
 		<szItemDesc>A modular leg rig panel with an AR-Mag. pouch, canteen pouch, and two grenade pouches.</szItemDesc>
-		<szBRName>AR-Mag. / Canteen / Grenade Panel</szBRName>
-		<szBRDesc>A sub-version of one of our other leg rigs, this panel replaces one grenade pouch with a canteen pouch.</szBRDesc>
+		<szBRName>AR-Mag. / Canteen / Grenade Rig</szBRName>
+		<szBRDesc>A sub-version of one of our other leg rigs, it replaces one grenade pouch with a canteen pouch.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ItemFlag>2147483648</ItemFlag>
@@ -38073,10 +38073,10 @@
 	<ITEM>
 		<uiIndex>1208</uiIndex>
 		<szItemName>L.Mag.-Ca.-Gr.</szItemName>
-		<szLongItemName>Large Mag. / Canteen / Grenade Panel</szLongItemName>
-		<szItemDesc>A leg panel with a canteen pouch, a grenade pouch, and two pouches for unusually long magazines.</szItemDesc>
-		<szBRName>Large Mag. / Canteen / Grenade Panel</szBRName>
-		<szBRDesc>This panel has a canteen pouch instead of a grenade pouch of our other large magazine pouch setup.</szBRDesc>
+		<szLongItemName>Large Mag. / Canteen / Grenade Rig</szLongItemName>
+		<szItemDesc>A leg rig with a canteen pouch, a grenade pouch, and two pouches for unusually long magazines.</szItemDesc>
+		<szBRName>Large Mag. / Canteen / Grenade Rig</szBRName>
+		<szBRDesc>This leg rig has a canteen pouch instead of a grenade pouch of our other large magazine pouch setup.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ItemFlag>2147483648</ItemFlag>
@@ -49517,7 +49517,7 @@
 	<ITEM>
 		<uiIndex>1644</uiIndex>
 		<szItemName>TK Rig</szItemName>
-		<szLongItemName>Leg Rig Throwing Knives</szLongItemName>
+		<szLongItemName>Throwing Knives Leg Rig</szLongItemName>
 		<szItemDesc>Stealthy assassins like their knives. This rig can hold several of them.</szItemDesc>
 		<szBRName>TK Rig</szBRName>
 		<szBRDesc>Stealthy assassins like their knives. This rig can hold several of them.</szBRDesc>
@@ -49541,9 +49541,9 @@
 	<ITEM>
 		<uiIndex>1645</uiIndex>
 		<szItemName>Pistol Magazines</szItemName>
-		<szLongItemName>Pistol Magazines</szLongItemName>
+		<szLongItemName>Pistol Mag Rig</szLongItemName>
 		<szItemDesc>A leg rig, with three pouches for pistol magazines.</szItemDesc>
-		<szBRName>Pistol Magazines</szBRName>
+		<szBRName>Pistol Mag Rig</szBRName>
 		<szBRDesc>A leg rig, with three pouches for pistol magazines.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -49564,11 +49564,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1646</uiIndex>
-		<szItemName>Equipment Pouch</szItemName>
-		<szLongItemName>Equipment Pouch</szLongItemName>
-		<szItemDesc>A versatile leg pouch, with pockets to carry various items.</szItemDesc>
-		<szBRName>Equipment Pouch</szBRName>
-		<szBRDesc>A versatile leg pouch, with pockets to carry various items.</szBRDesc>
+		<szItemName>Equipment Rig</szItemName>
+		<szLongItemName>Equipment Rig</szLongItemName>
+		<szItemDesc>A versatile leg pouch, with pockets to carry various items and mounted on a leg rig.</szItemDesc>
+		<szBRName>Equipment Rig</szBRName>
+		<szBRDesc>A versatile leg pouch, with pockets to carry various items and mounted on a leg rig.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ubClassIndex>46</ubClassIndex>
@@ -49588,11 +49588,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1647</uiIndex>
-		<szItemName>Bomb Pouch</szItemName>
-		<szLongItemName>Bomb Pouch</szLongItemName>
-		<szItemDesc>A leg rig, suitable for the safe transport of explosives.</szItemDesc>
-		<szBRName>Bomb Pouch</szBRName>
-		<szBRDesc>A leg rig, suitable for the safe transport of explosives.</szBRDesc>
+		<szItemName>Bomb Rig</szItemName>
+		<szLongItemName>Bomb Rig</szLongItemName>
+		<szItemDesc>Mounted on a leg rig, this pouch is suitable for the safe transport of explosives.</szItemDesc>
+		<szBRName>Bomb Rig</szBRName>
+		<szBRDesc>Mounted on a leg rig, this pouch is suitable for the safe transport of explosives.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<ItemFlag>2147483648</ItemFlag>
@@ -49663,7 +49663,7 @@
 		<szItemName>3.11 Pouch</szItemName>
 		<szLongItemName>3.11 Horizontal Pouch</szLongItemName>
 		<szItemDesc>This MOLLE pouch is one large compartment with two drain holes on the bottom and a zipper along the full width of the top.</szItemDesc>
-		<szBRName>3.11 Horizontal Pouch</szBRName>
+		<szBRName>3.11 Pouch</szBRName>
 		<szBRDesc>This MOLLE pouch is one large compartment with two drain holes on the bottom and a zipper along the full width of the top.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -49689,11 +49689,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1651</uiIndex>
-		<szItemName>MLBE Vest</szItemName>
-		<szLongItemName>3.11 Tactical Vest</szLongItemName>
-		<szItemDesc>Customizable tactical MOLLE utility with high impact fastening grips and hidden document pockets.</szItemDesc>
-		<szBRName>3.11 Tactical Vest</szBRName>
-		<szBRDesc>Our MOLLE Vest is made from a stiffened mesh, providing the necessary structure for your gear, and is fully compatible with our standard NAS gear.</szBRDesc>
+		<szItemName>M-LBE Vest</szItemName>
+		<szLongItemName>3.11 Tactical M-LBE Vest</szLongItemName>
+		<szItemDesc>Customizable tactical MOLLE utility vest with high impact fastening grips and hidden document pockets.</szItemDesc>
+		<szBRName>3.11 M-LBE Vest</szBRName>
+		<szBRDesc>Our tactical M-LBE vest is made from a stiffened mesh, providing the necessary structure for your gear, and is fully compatible with our standard MOLLE gear.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<AvailableAttachmentPoint>1</AvailableAttachmentPoint>
@@ -49717,7 +49717,7 @@
 		<szItemName>Ammo Belt</szItemName>
 		<szLongItemName>3.11 Ammo Belt</szLongItemName>
 		<szItemDesc>Customize your load-bearing equipment according to your own wishes! This MOLLE pouch is medium-sized.</szItemDesc>
-		<szBRName>3.11  Ammo Belt</szBRName>
+		<szBRName>3.11 Ammo Belt</szBRName>
 		<szBRDesc>Customize your load-bearing equipment according to your own wishes! This MOLLE pouch is medium-sized.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -49774,7 +49774,7 @@
 		<uiIndex>1654</uiIndex>
 		<szItemName>Mini Frag Pouch</szItemName>
 		<szLongItemName>3.11 Mini Frag Pouch</szLongItemName>
-		<szItemDesc>Made of durable 1000D nylon and a quality Velcro closure, the Grenade MOLLE pouch is high-quality at a great price.</szItemDesc>
+		<szItemDesc>Made of durable 1000D nylon and a quality Velcro closure, the MOLLE Grenade pouch is high-quality at a great price.</szItemDesc>
 		<szBRName>3.11 MiniFrag Pouch</szBRName>
 		<szBRDesc>The 3.11 MOLLE Frag Pouch is built to accommodate 2 small grenades.</szBRDesc>
 		<usItemClass>131072</usItemClass>
@@ -49806,7 +49806,7 @@
 		<szLongItemName>3.11 Double MP5 Pouch</szLongItemName>
 		<szItemDesc>Engineered for tactical and law enforcement use, the MOLLE suited MP5 Double Bungee Cover Pouch provides quick and secure access to any standard 9mm magazine.</szItemDesc>
 		<szBRName>3.11 Double MP5 Pouch</szBRName>
-		<szBRDesc>Featuring complete compatibility with 3.11 NAS and MOLLE web gear platforms.</szBRDesc>
+		<szBRDesc>Featuring complete compatibility with 3.11 MOLLE web gear platforms.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
 		<nasAttachmentClass>4096</nasAttachmentClass>
@@ -49834,8 +49834,8 @@
 		<szItemName>H2O Carrier</szItemName>
 		<szLongItemName>3.11 H2O Carrier</szLongItemName>
 		<szItemDesc>The high-impact locking clip keeps a water bottle secure and is easily accessible by attaching it to any standard MOLLE web platform.</szItemDesc>
-		<szBRName>H2O Carrier</szBRName>
-		<szBRDesc>The 3.11 H20 Carrier is sized for a standard water bottle and integrates with MOLLE and NAS web platforms.</szBRDesc>
+		<szBRName>3.11 H2O Carrier</szBRName>
+		<szBRDesc>The 3.11 H20 Carrier is sized for a standard water bottle and integrates with any MOLLE web platforms.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
 		<nasAttachmentClass>4096</nasAttachmentClass>
@@ -49890,9 +49890,9 @@
 		<uiIndex>1658</uiIndex>
 		<szItemName>3.11 Med Pouch</szItemName>
 		<szLongItemName>3.11 Med Pouch</szLongItemName>
-		<szItemDesc>With MOLLE attachment system compatibility for the 3.11 system, the Med Pouch adds a mesh interior pocket.</szItemDesc>
+		<szItemDesc>With attachment system compatibility for the 3.11  MOLLE system, the Med Pouch adds a mesh interior pocket that can safely store 1st-Aid kits.</szItemDesc>
 		<szBRName>3.11 Med Pouch</szBRName>
-		<szBRDesc>The 3.11 Medic Pouch meshes seamlessly with 3.11 MOLLE bags, providing a quick first aid solution for any application or environment.</szBRDesc>
+		<szBRDesc>The 3.11 Medic Pouch meshes seamlessly with other 3.11 MOLLE bags, providing quick access to 1st-Aid supplies in any situation or environment.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
 		<nasAttachmentClass>4096</nasAttachmentClass>
@@ -49946,10 +49946,10 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1660</uiIndex>
-		<szItemName>Knife Holster</szItemName>
+		<szItemName>Nylon Sheath</szItemName>
 		<szLongItemName>3.11 Nylon Knife Sheath</szLongItemName>
-		<szItemDesc>A small, compact clip on nylon sheath that accepts most combat knives and fits most MOLLE carriers.</szItemDesc>
-		<szBRName>3.11 Knife Holster</szBRName>
+		<szItemDesc>A small, compact clip on nylon sheath that accepts most combat knives. Fits most MOLLE carriers.</szItemDesc>
+		<szBRName>3.11 Nylon Sheath</szBRName>
 		<szBRDesc>A quick and easy knife sheath. Fits most MOLLE carriers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50037,7 +50037,7 @@
 		<szItemName>3.11 SG Bandolier</szItemName>
 		<szLongItemName>3.11 7 RD Shotgun Bandolier</szLongItemName>
 		<szItemDesc>This MOLLE  Shotgun Bandolier holds 7 shotgun shell rounds.</szItemDesc>
-		<szBRName>7 RD SG Bandolier</szBRName>
+		<szBRName>3.11 7RD SG Bandolier</szBRName>
 		<szBRDesc>The 7 RD Shotgun Bandolier keeps your shotgun reloads within easy reach. Attachable to most MOLLE carriers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50065,7 +50065,7 @@
 		<szItemName>Documents</szItemName>
 		<szLongItemName>3.11 Document Drop Pouch</szLongItemName>
 		<szItemDesc>Our Drop Pouch attaches to any MOLLE-compatible system or standard belt to hold vital maps and other paperwork.</szItemDesc>
-		<szBRName>Document Drop Pouch</szBRName>
+		<szBRName>3.11 Document Pouch</szBRName>
 		<szBRDesc>Designed to provide expandable storage space on demand, the Document Drop Pouch remains folded and compact when not in use. Attaches to any MOLLE-compatible system.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50094,7 +50094,7 @@
 		<szItemName>Drop Holster</szItemName>
 		<szLongItemName>3.11 Drop Leg Holster</szLongItemName>
 		<szItemDesc>The LBT-6099Z is an ambidextrous, modular style, universal holster. A variety of MOLLE-compatible pouches can be attached.</szItemDesc>
-		<szBRName>Drop Leg Ambi Holster</szBRName>
+		<szBRName>3.11 Drop Holster</szBRName>
 		<szBRDesc>Versatility comes from the number of carry modes and weapon configurations allowed by this holster and it being MOLLE-compatible.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -50115,11 +50115,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1666</uiIndex>
-		<szItemName>Casualty Response Kit</szItemName>
-		<szLongItemName>3.11 Casualty Response Kit</szLongItemName>
+		<szItemName>Casualty Response Rig</szItemName>
+		<szLongItemName>3.11 Casualty Response Rig</szLongItemName>
 		<szItemDesc>Trauma shear storage for quick access and MOLLE-style attachment system-compatible.</szItemDesc>
-		<szBRName>Casualty Response Kit</szBRName>
-		<szBRDesc>Here we have a Trauma shear storage for quick access and it's MOLLE-style attachment system-compatible.</szBRDesc>
+		<szBRName>3.11 Casualty Response</szBRName>
+		<szBRDesc>Here we have a Trauma shear storage for quick access and it's MOLLE-style attachment system-compatible. Mounted on a leg rig.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
 		<AvailableAttachmentPoint>3</AvailableAttachmentPoint>
@@ -50142,9 +50142,9 @@
 		<uiIndex>1667</uiIndex>
 		<szItemName>Black MOLLE</szItemName>
 		<szLongItemName>3.11 Black Modular Vest</szLongItemName>
-		<szItemDesc>This black tactical vest is almost completely covered in MOLLE compatible webbing, making it easy to attach all the gear you need.</szItemDesc>
-		<szBRName>Black Modular Vest</szBRName>
-		<szBRDesc>This military vest has hanging loops for added storage and features two inner mesh pockets with zippers, perfect for carrying smaller items that cannot be attached to the MOLLE webbing.</szBRDesc>
+		<szItemDesc>This black tactical vest is almost completely covered in 3.11 MOLLE compatible webbing, making it easy to attach all the gear you need.</szItemDesc>
+		<szBRName>Black 3.11 Vest</szBRName>
+		<szBRDesc>This military vest has hanging loops for added storage and features two inner mesh pockets with zippers, perfect for carrying smaller items that cannot be attached to the 3.11 MOLLE webbing.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<AvailableAttachmentPoint>3</AvailableAttachmentPoint>
@@ -50169,7 +50169,7 @@
 		<szItemName>Multicam Vest</szItemName>
 		<szLongItemName>3.11 Multicam Vest</szLongItemName>
 		<szItemDesc>The Multicam MOLLE  tactical vest is mounted on tough mesh material for superior ventilation, and is equipped with a multitude of ammo pouches and holsters for all your firearms.</szItemDesc>
-		<szBRName>Multicam Molle Vest</szBRName>
+		<szBRName>3.11 Multicam Vest</szBRName>
 		<szBRDesc>The Multicam MOLLE compatible cross draw military vest is the maximum in practicality and durability for a tactical vest.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
@@ -50194,9 +50194,9 @@
 		<uiIndex>1669</uiIndex>
 		<szItemName>TK Sheath</szItemName>
 		<szLongItemName>3.11 Throwing Knife Sheath</szLongItemName>
-		<szItemDesc>3.11 MOLLE pouches are designed to give you maximum flexibility when creating your personal rig.</szItemDesc>
-		<szBRName>Throwing Knife Sheath</szBRName>
-		<szBRDesc>Swift access to your blades, fits most MOLLE carrier systems.</szBRDesc>
+		<szItemDesc>3.11 MOLLE pouches are designed to give you maximum flexibility when creating your personal rig. This sheath allows for carrying throwing knives.</szItemDesc>
+		<szBRName>3.11 TK Sheath</szBRName>
+		<szBRDesc>Swift access to your throwing knives, fits most MOLLE carrier systems.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
 		<nasAttachmentClass>4096</nasAttachmentClass>
@@ -50224,7 +50224,7 @@
 		<szItemName>12G Pouch</szItemName>
 		<szLongItemName>3.11 Shotgun Ammo Pouch</szLongItemName>
 		<szItemDesc>This versatile MOLLE shotgun pouch gives you quick access to the rounds you need.</szItemDesc>
-		<szBRName>3.11 Shotgun Ammo Pouch</szBRName>
+		<szBRName>3.11 SG Ammo Pouch</szBRName>
 		<szBRDesc>The quick and simple 3.11 MOLLE Shotgun Ammo Pouch provides easy and reliable access to standard shotgun rounds.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50250,10 +50250,10 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1671</uiIndex>
-		<szItemName>Small Drop</szItemName>
+		<szItemName>Small Pouch</szItemName>
 		<szLongItemName>3.11 Small Drop Pouch</szLongItemName>
 		<szItemDesc>Our Drop Pouch attaches to any MOLLE-compatible system or standard belt to hold vital gear.</szItemDesc>
-		<szBRName>Small Drop Pouch</szBRName>
+		<szBRName>3.11 Small Pouch</szBRName>
 		<szBRDesc>Designed to provide expandable storage space on demand, the Small MOLLE Drop Pouch remains folded and compact when not in use.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50282,7 +50282,7 @@
 		<szItemName>Sniper Pouch</szItemName>
 		<szLongItemName>3.11 Sniper Ammo Pouch</szLongItemName>
 		<szItemDesc>Our Ammo Pouches attach to any MOLLE-compatible system or standard belt to hold vital ammunition.</szItemDesc>
-		<szBRName>Sniper Ammo Pouch</szBRName>
+		<szBRName>3.11 Sniper Ammo Pouch</szBRName>
 		<szBRDesc>Our Ammo Pouches attaches to any MOLLE-compatible system or standard belt to hold vital ammunition.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50311,7 +50311,7 @@
 		<szItemName>Rifle Pouch</szItemName>
 		<szLongItemName>3.11 Rifle Ammo Pouch</szLongItemName>
 		<szItemDesc>Our Ammo Pouches attach to any MOLLE-compatible system or standard belt to hold vital ammunition.</szItemDesc>
-		<szBRName>Rifle Ammo Pouch</szBRName>
+		<szBRName>3.11 Rifle Ammo Pouch</szBRName>
 		<szBRDesc>Our Ammo Pouches attaches to any MOLLE-compatible system or standard belt to hold vital ammunition.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50337,10 +50337,10 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1674</uiIndex>
-		<szItemName>Knife Sheath</szItemName>
+		<szItemName>Leather Sheath</szItemName>
 		<szLongItemName>3.11 Leather Knife Sheath</szLongItemName>
 		<szItemDesc>Clip point Bowie knife and drop loop sheath with front arch over the guard, attachable to a variety of MOLLE carriers.</szItemDesc>
-		<szBRName>Leather Knife Sheath</szBRName>
+		<szBRName>3.11 Leather Sheath</szBRName>
 		<szBRDesc>Clip point Bowie knife and drop loop sheath with front arch over the guard, attachable to a variety of MOLLE carriers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50368,7 +50368,7 @@
 		<szItemName>Revolver Pouch</szItemName>
 		<szLongItemName>3.11 Revolver Pouch</szLongItemName>
 		<szItemDesc>M81 US Woodland Nylon Revolver pouch, made in China. Fits most MOLLE systems.</szItemDesc>
-		<szBRName>Revolver Pouch</szBRName>
+		<szBRName>3.11 Revolver Pouch</szBRName>
 		<szBRDesc>M81 US Woodland Nylon Revolver pouch, made in China. Fits most MOLLE systems.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50397,7 +50397,7 @@
 		<szItemName>Specter Rig</szItemName>
 		<szLongItemName>3.11 Specter Thigh Rig</szLongItemName>
 		<szItemDesc>This rig features 4 rows of MOLLE-compatible modular webbing strips and a loop for a gasmask.</szItemDesc>
-		<szBRName>Specter Thigh Rig</szBRName>
+		<szBRName>3.11 Specter Rig</szBRName>
 		<szBRDesc>This rig features 4 rows of MOLLE-compatible modular webbing strips that allow the user to configure a thigh rig with the pouches they need for the mission at hand.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -50423,7 +50423,7 @@
 		<szItemName>Russian Holster</szItemName>
 		<szLongItemName>3.11 Russian Pistol holster</szLongItemName>
 		<szItemDesc>This MOLLE holster may be used for Glock, PMM, APS, GSh-18, and PB pistols with a silencer.</szItemDesc>
-		<szBRName>Russian Pistol holster</szBRName>
+		<szBRName>3.11 Ru. Pistol Holster</szBRName>
 		<szBRDesc>This MOLLE holster may be used for Glock, PMM, APS, GSh-18, and PB pistols with a silencer.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50450,10 +50450,10 @@
 	<ITEM>
 		<uiIndex>1678</uiIndex>
 		<szItemName>Rifle Grenade</szItemName>
-		<szLongItemName>3.11 Rifle Grenade</szLongItemName>
-		<szItemDesc>3.11 Tactical bring you the MOLLE Magazine Pouches. These Pouches will securely carry your Rifle Grenades.</szItemDesc>
+		<szLongItemName>3.11 Double Rifle Grenade</szLongItemName>
+		<szItemDesc>3.11 Tactical bring you the MOLLE Magazine Pouches. These Pouches will securely carry up to two of your Rifle Grenades.</szItemDesc>
 		<szBRName>3.11 Double Rifle Grenade</szBRName>
-		<szBRDesc>3.11 Tactical bring you the MOLLE Magazine Pouches. These Pouches will securely carry your Rifle Grenades.</szBRDesc>
+		<szBRDesc>3.11 Tactical bring you the MOLLE Magazine Pouches. These Pouches will securely carry up to two of your Rifle Grenades.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
 		<nasAttachmentClass>4096</nasAttachmentClass>
@@ -50480,9 +50480,9 @@
 	<ITEM>
 		<uiIndex>1679</uiIndex>
 		<szItemName>Pistol Mag</szItemName>
-		<szLongItemName>3.11 Single Pistol Mag</szLongItemName>
+		<szLongItemName>3.11 Single Pistol Mag Pouch</szLongItemName>
 		<szItemDesc>3.11 Tactical bring you the MOLLE Magazine Pouches. These Magazine Pouches will securely carry your pistol magazine and provide quick access when it's time to reload.</szItemDesc>
-		<szBRName>3.11 Single Pistol Pouch</szBRName>
+		<szBRName>3.11 Single Pistol Mag</szBRName>
 		<szBRDesc>The MOLLE  Magazine Pouches accommodate a variety of magazines. Be sure to select the correct magazine pouches for your pistol magazines.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50509,9 +50509,9 @@
 	<ITEM>
 		<uiIndex>1680</uiIndex>
 		<szItemName>AR Pouch</szItemName>
-		<szLongItemName>3.11 AR Mag</szLongItemName>
+		<szLongItemName>3.11 Double AR Mag</szLongItemName>
 		<szItemDesc>The MOLLE Stacker Magazine Pouch is made to fit (2) 5.56 30 round magazines for M16/M4-series rifles</szItemDesc>
-		<szBRName>Stacked Double AR Pouch</szBRName>
+		<szBRName>3.11 AR Mag</szBRName>
 		<szBRDesc>The TAG MOLLE Stacker Magazine Pouch is made to fit (2) 5.56 30 round magazines for M16/M4-series rifles</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50540,7 +50540,7 @@
 		<szItemName>Kit Pouch</szItemName>
 		<szLongItemName>3.11 Kit Drop Pouch</szLongItemName>
 		<szItemDesc>Designed to provide expandable storage space on demand, the Kit Drop Pouch is perfect for storing your Camo. Compatible to most MOLLE systems.</szItemDesc>
-		<szBRName>Kit Drop Pouch</szBRName>
+		<szBRName>3.11 Kit Pouch</szBRName>
 		<szBRDesc>Designed to provide expandable storage space on demand, the Kit Drop Pouch is perfect for storing your Camo. Compatible to most MOLLE systems.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50566,11 +50566,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1682</uiIndex>
-		<szItemName>MAT-V</szItemName>
-		<szLongItemName>3.11 TT Modular Vest</szLongItemName>
-		<szItemDesc>The TT Modular Adjustable Tactical Vest is a modern update to the traditional modular vest, capable of attaching a variety of MOLLE equipment.</szItemDesc>
-		<szBRName>TT Modular Tactical Vest</szBRName>
-		<szBRDesc>The Modular Adjustable Tactical Vest is a modern MOLLE vest. The MAT-V has been designed to combine function and comfort without sacrificing either.</szBRDesc>
+		<szItemName>MAT Vest</szItemName>
+		<szLongItemName>3.11 TT Modular Adjustable Tactical Vest</szLongItemName>
+		<szItemDesc>The TT Modular Adjustable Tactical (MAT) Vest is a modern update to the traditional modular vest, capable of attaching a variety of MOLLE equipment.</szItemDesc>
+		<szBRName>3.11 MAT Vest</szBRName>
+		<szBRDesc>The TT Modular Adjustable Tactical (MAT) Vest is a modern MOLLE vest. The MAT-V has been designed to combine function and comfort without sacrificing either.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<AvailableAttachmentPoint>3</AvailableAttachmentPoint>
@@ -50592,9 +50592,9 @@
 	<ITEM>
 		<uiIndex>1683</uiIndex>
 		<szItemName>S.T.R.I.K.E.</szItemName>
-		<szLongItemName>3.11 S.T.R.I.K.E. Vest</szLongItemName>
+		<szLongItemName>3.11 S.T.R.I.K.E. Elite Vest</szLongItemName>
 		<szItemDesc>Two large, zippered map pouches inside, Shoulder D-rings for accessory attachment. See 3.11. MOLLE section for all pouch options.</szItemDesc>
-		<szBRName>S.T.R.I.K.E. Elite Vest</szBRName>
+		<szBRName>3.11 S.T.R.I.K.E. Vest</szBRName>
 		<szBRDesc>Two large, zippered map pouches inside, Shoulder D-rings for accessory attachment. See 3.11. MOLLE section for all pouch options.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
@@ -50616,10 +50616,10 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1684</uiIndex>
-		<szItemName>Drop Pouch</szItemName>
+		<szItemName>Medium Pouch</szItemName>
 		<szLongItemName>3.11 Medium Drop Pouch</szLongItemName>
 		<szItemDesc>Our Drop Pouch attaches to any MOLLE compatible system or standard belt to hold vital gear.</szItemDesc>
-		<szBRName>Medium Drop Pouch</szBRName>
+		<szBRName>3.11 Medium Pouch</szBRName>
 		<szBRDesc>Designed to provide expandable storage space on demand, our MOLLE Drop Pouch remains folded and compact when not in use.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50677,7 +50677,7 @@
 		<szItemName>Triple Grenade</szItemName>
 		<szLongItemName>3.11 Triple Grenade Pouch</szLongItemName>
 		<szItemDesc>Heavy duty pockets for the safe storage of three MK2 defensive grenades. Fits a variety of MOLLE carriers.</szItemDesc>
-		<szBRName>Triple Grenade Pouch</szBRName>
+		<szBRName>3.11 Triple Grenade Pouch</szBRName>
 		<szBRDesc>Heavy duty pockets for the safe storage of three MK2 defensive grenades. Fits a variety of MOLLE carriers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50704,10 +50704,10 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1687</uiIndex>
-		<szItemName>Flashbang Pouch</szItemName>
+		<szItemName>Triple FB Pouch</szItemName>
 		<szLongItemName>3.11 Triple Flashbang Pouch</szLongItemName>
 		<szItemDesc>Safely store up to three Flashbang Grenades with this MOLLE compatible pouch.</szItemDesc>
-		<szBRName>Triple Flashbang Pouch</szBRName>
+		<szBRName>3.11 Triple FB Pouch</szBRName>
 		<szBRDesc>Safely store up to three Flashbang Grenades with this MOLLE compatible pouch.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50737,7 +50737,7 @@
 		<szItemName>Triple Pistol Mag</szItemName>
 		<szLongItemName>3.11 Triple Pistol Mag Pouch</szLongItemName>
 		<szItemDesc>Attaches to any MOLLE compatible system and can hold up to three single stack pistol magazines.</szItemDesc>
-		<szBRName>Triple Pistol Mag Pouch</szBRName>
+		<szBRName>3.11 Triple Pistol Mag</szBRName>
 		<szBRDesc>Attaches to any MOLLE compatible system and can hold up to three single stack pistol magazines.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50766,7 +50766,7 @@
 		<szItemName>Triple SMG Mag</szItemName>
 		<szLongItemName>3.11 Triple SMG Mag Pouch</szLongItemName>
 		<szItemDesc>Attaches to any MOLLE compatible system and can hold up to three single stack SMG magazines.</szItemDesc>
-		<szBRName>Triple SMG Mag Pouch</szBRName>
+		<szBRName>3.11 Triple SMG Mag</szBRName>
 		<szBRDesc>Attaches to any MOLLE compatible system and can hold up to three single stack SMG magazines.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50795,7 +50795,7 @@
 		<szItemName>Large Thigh Rig</szItemName>
 		<szLongItemName>3.11 Large Modular Thigh Rig</szLongItemName>
 		<szItemDesc>This rig features 5 rows of MOLLE compatible modular webbing strips that allow the user to configure a tactical thigh rig with exactly the right pouches they want.</szItemDesc>
-		<szBRName>Large Modular Thigh Rig</szBRName>
+		<szBRName>3.11 Large Thigh Rig</szBRName>
 		<szBRDesc>This rig features 5 rows of MOLLE compatible modular webbing strips that allow the user to configure a tactical thigh rig with exactly the right pouches they want.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>4</nasLayoutClass>
@@ -50843,9 +50843,9 @@
 		<uiIndex>1692</uiIndex>
 		<szItemName>Sporting Clay Vest</szItemName>
 		<szLongItemName>3.11 Sporting Clay Vest</szLongItemName>
-		<szItemDesc>This versatile, value-priced vest has plenty of range-perfect features. Organize loads between two double shell pockets, or further expand with MOLLE compatible pouches.</szItemDesc>
-		<szBRName>Sporting Clay Vest</szBRName>
-		<szBRDesc>This versatile, value-priced vest has plenty of range-perfect features. Organize loads between two double shell pockets, or further expand with MOLLE compatible pouches.</szBRDesc>
+		<szItemDesc>This versatile, value-priced vest has plenty of range-perfect features. Organize loads between two double shell pockets, or even further expand with MOLLE compatible pouches.</szItemDesc>
+		<szBRName>3.11 Sporting Clay Vest</szBRName>
+		<szBRDesc>This versatile, value-priced vest has plenty of range-perfect features. Organize loads between two double shell pockets, or even further expand with MOLLE compatible pouches.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<AvailableAttachmentPoint>1</AvailableAttachmentPoint>
@@ -50866,10 +50866,10 @@
 	<ITEM>
 		<uiIndex>1693</uiIndex>
 		<szItemName>Condor Vest</szItemName>
-		<szLongItemName>3.11 Condor Assault Vest</szLongItemName>
-		<szItemDesc>When the job is going to get messy, you need the Heavy Assault Vest. The vest itself is a MOLLE system which means that shooters can configure the vest to their own specifications.</szItemDesc>
-		<szBRName>Condor Heavy Assault Vest</szBRName>
-		<szBRDesc>When the job is going to get messy, you need the Heavy Assault Vest. The vest itself is a MOLLE system which means that shooters can configure the vest to their own specifications.</szBRDesc>
+		<szLongItemName>3.11 Condor Heavy Assault Vest</szLongItemName>
+		<szItemDesc>When the job is going to get messy, you need the Condor Heavy Assault Vest. The vest itself is a MOLLE system which means that shooters can configure the vest to their own specifications.</szItemDesc>
+		<szBRName>3.11 Condor Vest</szBRName>
+		<szBRDesc>When the job is going to get messy, you need the Condor Heavy Assault Vest. The vest itself is a MOLLE system which means that shooters can configure the vest to their own specifications.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
 		<AvailableAttachmentPoint>1</AvailableAttachmentPoint>
@@ -50893,7 +50893,7 @@
 		<szItemName>Archer Vest</szItemName>
 		<szLongItemName>3.11 Archer Assault Vest</szLongItemName>
 		<szItemDesc>Chinese made Special force load bearing vest with MOLLE webbing cross straps for attaching MOLLE pouches.</szItemDesc>
-		<szBRName>Archer Assault Vest</szBRName>
+		<szBRName>3.11 Archer Vest</szBRName>
 		<szBRDesc>Chinese made Special force load bearing vest with MOLLE webbing cross straps for attaching MOLLE pouches.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>8</nasLayoutClass>
@@ -50916,9 +50916,9 @@
 	<ITEM>
 		<uiIndex>1695</uiIndex>
 		<szItemName>Carabiner</szItemName>
-		<szLongItemName>Carabiner</szLongItemName>
+		<szLongItemName>3.11 Carabiner</szLongItemName>
 		<szItemDesc>Functional shape is easy to hold; deep basket accepts loads of slings and runners. A perfect fit for any MOLLE system.</szItemDesc>
-		<szBRName>Carabiner</szBRName>
+		<szBRName>3.11 Carabiner</szBRName>
 		<szBRDesc>Functional shape is easy to hold; deep basket accepts loads of slings and runners. A perfect fit for any MOLLE system.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -50949,7 +50949,7 @@
 		<szItemName>Double Grenade</szItemName>
 		<szLongItemName>3.11 Double Grenade Pouch</szLongItemName>
 		<szItemDesc>Heavy duty pockets for the safe storage of two MK 2 Defensive Grenades, fits a range of MOLLE carriers.</szItemDesc>
-		<szBRName>Double Grenade Pouch</szBRName>
+		<szBRName>3.11 Double Grenade Pouch</szBRName>
 		<szBRDesc>Heavy duty pockets for the safe storage of two  MK 2 Defensive Grenades, fits a range of MOLLE carriers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -51170,8 +51170,8 @@
 		<szItemName>USMC Backpack</szItemName>
 		<szLongItemName>3.11 ILBE Gen II Main Ruck</szLongItemName>
 		<szItemDesc>The Improved Load-Bearing System backpack was created for use by the US Marine Corps, based on feedback received from initial combat situations during the first US involvement in Iraq. MOLLE compatible, comes with Hydration Carrier to fit a Bladder.</szItemDesc>
-		<szBRName>USMC Backpack</szBRName>
-		<szBRDesc>The ILBE system consists of three main parts, the Main Pack, the Hydration System, and the Assault Pack. MOLLE compatible and the included Hydration Carrier can fit a Bladder.</szBRDesc>
+		<szBRName>3.11 USMC Backpack</szBRName>
+		<szBRDesc>The ILBE system consists of three main parts, the Main Pack, the Hydration System, and the Assault Pack. MOLLE compatible, comes with Hydration Carrier to fit a Bladder.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>32</nasLayoutClass>
 		<AvailableAttachmentPoint>7</AvailableAttachmentPoint>
@@ -51193,9 +51193,9 @@
 	<ITEM>
 		<uiIndex>1706</uiIndex>
 		<szItemName>USMC Assault Pack</szItemName>
-		<szLongItemName>3.11 ILBE Gen II Assault</szLongItemName>
+		<szLongItemName>3.11 ILBE Gen II Assault Pack</szLongItemName>
 		<szItemDesc>There are MOLLE webbing straps on the main outer panel and sides. Two straps and clips on each side are used for compression, or attaching to the ILBE main pack.</szItemDesc>
-		<szBRName>USMC Assault Pack</szBRName>
+		<szBRName>3.11 USMC Assault Pack</szBRName>
 		<szBRDesc>There are MOLLE webbing straps on the main outer panel and sides. Two straps and clips on each side are used for compression, or attaching to the ILBE main pack.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>16</nasLayoutClass>
@@ -51218,10 +51218,10 @@
 	<ITEM>
 		<uiIndex>1707</uiIndex>
 		<szItemName>TT Range</szItemName>
-		<szLongItemName>3.11 TT Extended Range</szLongItemName>
-		<szItemDesc>The largest of our Operator series packs is the Extended Range Operator Pack. Its large size and extensive list of features makes it essential for longer missions. Fully MOLLE compatible, can fit the ArmorBak Hydration Carrier.</szItemDesc>
-		<szBRName>TT Extended Range</szBRName>
-		<szBRDesc>The largest of our Operator series packs is the Extended Range Operator Pack. Its large size and extensive list of features makes it essential for longer missions. Fully MOLLE compatible, can fit the ArmorBak Hydration Carrier.</szBRDesc>
+		<szLongItemName>3.11 TT Extended Range Operator</szLongItemName>
+		<szItemDesc>The largest of our Operator series packs is the Extended Range Operator backpack. Its large size and extensive list of features makes it essential for longer missions. Fully MOLLE compatible, can fit the ArmorBak Hydration Carrier.</szItemDesc>
+		<szBRName>3.11 TT Range</szBRName>
+		<szBRDesc>The largest of our Operator series packs is the Extended Range Operator backpack. Its large size and extensive list of features makes it essential for longer missions. Fully MOLLE compatible, can fit the ArmorBak Hydration Carrier.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>32</nasLayoutClass>
 		<AvailableAttachmentPoint>7</AvailableAttachmentPoint>
@@ -51242,9 +51242,9 @@
 	<ITEM>
 		<uiIndex>1708</uiIndex>
 		<szItemName>TT Mod Pack</szItemName>
-		<szLongItemName>3.11 TT Modular Pack</szLongItemName>
+		<szLongItemName>3.11 TT Modular Operator Pack</szLongItemName>
 		<szItemDesc>The Modular Operator Pack is the mid-level, three day pack style entry in our Operator line of packs. Comparable in size to a regular three day pack, but expandable with MOLLE.</szItemDesc>
-		<szBRName>TT Modular Pack</szBRName>
+		<szBRName>3.11 TT Mod Pack</szBRName>
 		<szBRDesc>The Modular Operator Pack is the mid-level, three day pack style entry in our Operator line of packs. Comparable in size to a regular three day pack, but expandable with MOLLE. </szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<nasLayoutClass>16</nasLayoutClass>
@@ -51433,10 +51433,10 @@
 	<ITEM>
 		<uiIndex>1715</uiIndex>
 		<szItemName>Bladder</szItemName>
-		<szLongItemName>3.11 Hydration Bladder</szLongItemName>
-		<szItemDesc>An individual hydration system for use with the ArmorBAk Hydration Carrier (included in ILBE USMC Backpack and the TT Range Backpack can be equiped with that).</szItemDesc>
+		<szLongItemName>Hydration Bladder</szLongItemName>
+		<szItemDesc>An individual hydration system for use with the ArmorBAk Hydration Carrier (MOLLE-systems can be equiped with carrier, already included in USMC Backpack).</szItemDesc>
 		<szBRName>Bladder</szBRName>
-		<szBRDesc>An individual hydration system for use with the ArmorBAk Hydration Carrier (included in ILBE USMC Backpack and the TT Range Backpack can be equiped with that). The ideal solution for long expeditions.</szBRDesc>
+		<szBRDesc>An individual hydration system for use with the ArmorBAk Hydration Carrier (MOLLE-systems can be equiped with carrier, already included in USMC Backpack). The ideal solution for long expeditions.</szBRDesc>
 		<usItemClass>268435456</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
 		<ubGraphicType>2</ubGraphicType>
@@ -51461,10 +51461,10 @@
 	<ITEM>
 		<uiIndex>1716</uiIndex>
 		<szItemName>ArmorBak</szItemName>
-		<szLongItemName>3.11 ArmorBak Carrier</szLongItemName>
-		<szItemDesc>Lightweight and simple to use hydration system. Simply attach a Hydration Bladder to complete the system. Fits TT Range Backpack, already included in USMC Backpack.</szItemDesc>
-		<szBRName>ArmorBak Hydration Carrier</szBRName>
-		<szBRDesc>Lightweight and simple to use hydration system. Simply attach a Hydration Bladder to complete the system. Fits TT Range Backpack, already included in USMC Backpack.</szBRDesc>
+		<szLongItemName>3.11 ArmorBak  Hydration Carrier</szLongItemName>
+		<szItemDesc>Lightweight and simple to use hydration system carrier. Simply attach a Hydration Bladder to complete the system. Also fits a variety of MOLLE-systems (already included in USMC Backpack).</szItemDesc>
+		<szBRName>3.11 ArmorBak</szBRName>
+		<szBRDesc>Lightweight and simple to use hydration system carrier. Simply attach a Hydration Bladder to complete the system. Also fits a variety of MOLLE-systems (already included in USMC Backpack).</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
 		<nasAttachmentClass>8192</nasAttachmentClass>
@@ -51490,9 +51490,9 @@
 	<ITEM>
 		<uiIndex>1717</uiIndex>
 		<szItemName>Sp. Loader</szItemName>
-		<szLongItemName>3.11 Speed Loader</szLongItemName>
+		<szLongItemName>3.11 Speed Loader Pouch</szLongItemName>
 		<szItemDesc>Heavy duty MOLLE pockets for the safe storage of Speed Loaders.</szItemDesc>
-		<szBRName>Speed Loader Pouch</szBRName>
+		<szBRName>3.11 Sp. Loader Pouch</szBRName>
 		<szBRDesc>Heavy duty MOLLE pockets for the safe storage of Speed Loaders.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -51521,7 +51521,7 @@
 		<szItemName>Single Rifle Pouch</szItemName>
 		<szLongItemName>3.11 Single Rifle Pouch</szLongItemName>
 		<szItemDesc>Our Ammo Pouches attach to any MOLLE compatible system or standard belt to hold vital ammunition.</szItemDesc>
-		<szBRName>Single Rifle Pouch</szBRName>
+		<szBRName>3.11 Single Rifle Pouch</szBRName>
 		<szBRDesc>Our Ammo Pouches attaches to any MOLLE compatible system or standard belt to hold vital ammunition.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>
@@ -51550,7 +51550,7 @@
 		<szItemName>Drum Pouch</szItemName>
 		<szLongItemName>3.11 Drum Ammo Pouch</szLongItemName>
 		<szItemDesc>Perfect for carrying Drum shaped ammo, fits a variety of MOLLE carriers.</szItemDesc>
-		<szBRName>Drum Ammo Pouch</szBRName>
+		<szBRName>3.11 Drum Ammo</szBRName>
 		<szBRDesc>Perfect for carrying Drum shaped ammo, fits a variety of MOLLE carriers.</szBRDesc>
 		<usItemClass>131072</usItemClass>
 		<AttachmentClass>16777216</AttachmentClass>


### PR DESCRIPTION
adjusted some text to achieve a more consistent naming convention 
i.e., for leg rigs used "rig" instead of "pouch", etc. 
edited some description to highlight purpose and use 
i.e., mentioned the included hydration system on USMC backpack, etc.