### PR TITLE
Adjusted belt feeding

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -13559,7 +13559,7 @@
 		<uiIndex>470</uiIndex>
 		<szItemName>7.62x51mm Belt T</szItemName>
 		<szLongItemName>7.62x51mm Belt, Tracer</szLongItemName>
-		<szItemDesc>This belt of 7.62 NATO tracer will up the accuracy of your squad's force multiplier.</szItemDesc>
+		<szItemDesc>This belt has 100 rounds of 7.62 NATO tracer ammo, which certainly will up the accuracy of your squad's force multiplier.</szItemDesc>
 		<szBRName>7.62x51mm Belt Tracer</szBRName>
 		<szBRDesc>Tracer ammo, because seeing where your shots are going is just really damn cool.</szBRDesc>
 		<usItemClass>1024</usItemClass>
@@ -13587,7 +13587,7 @@
 		<uiIndex>471</uiIndex>
 		<szItemName>7.62x51mm Belt M</szItemName>
 		<szLongItemName>7.62x51mm Belt, Match</szLongItemName>
-		<szItemDesc>Extended range and extended feed are just what your LMG or SAW needs.</szItemDesc>
+		<szItemDesc>Extended range and extended feed are just what your LMG or SAW needs. 100 rounds of 7.62x51mm match ammo.</szItemDesc>
 		<szBRName>7.62x51mm Belt Match</szBRName>
 		<szBRDesc>Belt out some classic rock n' roll, louder and longer, with a belt of match quality ammo.</szBRDesc>
 		<usItemClass>1024</usItemClass>
@@ -13613,7 +13613,7 @@
 		<uiIndex>472</uiIndex>
 		<szItemName>7.62x51mm Belt HP C</szItemName>
 		<szLongItemName>7.62x51mm Belt, HP Cold</szLongItemName>
-		<szItemDesc>A belt load of quieter than normal hollow point 7.62x51mm.</szItemDesc>
+		<szItemDesc>A belt load of quieter than normal hollow point 7.62x51mm, 100 rounds of HP cold ammo.</szItemDesc>
 		<szBRName>7.62x51mm Belt HP Cold</szBRName>
 		<szBRDesc>This reduced noise ammo makes it much more difficult to pinpoint your LMG.</szBRDesc>
 		<usItemClass>1024</usItemClass>
@@ -13639,7 +13639,7 @@
 		<uiIndex>473</uiIndex>
 		<szItemName>7.62x51mm Belt C</szItemName>
 		<szLongItemName>7.62x51mm Belt, Cold</szLongItemName>
-		<szItemDesc>One belt of oh-so-quiet 7.62x51mm.</szItemDesc>
+		<szItemDesc>One belt of oh-so-quiet 7.62x51mm. 100 rounds of cold ammo.</szItemDesc>
 		<szBRName>7.62x51mm Belt Cold</szBRName>
 		<szBRDesc>Less noise, less stopping power, but this ammo still ensures a decent body count.</szBRDesc>
 		<usItemClass>1024</usItemClass>
@@ -14836,11 +14836,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>520</uiIndex>
-		<szItemName>7.62x54R Box AP</szItemName>
+		<szItemName>7.62x54R Belt AP</szItemName>
 		<szLongItemName>7.62x54R Box, AP</szLongItemName>
-		<szItemDesc>200 round box of 7.62x54 full metal jacket ammo.</szItemDesc>
+		<szItemDesc>200 round belt of 7.62x54 full metal jacket ammo.</szItemDesc>
 		<szBRName>7.62x54R Box AP</szBRName>
-		<szBRDesc>Crack open a box of 7.62x54R when its time to reload the squad PKM.</szBRDesc>
+		<szBRDesc>Crack open a b of 7.62x54R when its time to reload the squad PKM.</szBRDesc>
 		<usItemClass>1024</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
 		<ubClassIndex>453</ubClassIndex>
@@ -14861,11 +14861,11 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>521</uiIndex>
-		<szItemName>7.62x54R Box T</szItemName>
-		<szLongItemName>7.62x54R Box, Tracer</szLongItemName>
-		<szItemDesc>7.62x54R tracer rounds aid accurate burst fire.</szItemDesc>
-		<szBRName>7.62x54R Box Tracer</szBRName>
-		<szBRDesc>Adjusting automatic fire is an easy task with tracer ammo.</szBRDesc>
+		<szItemName>7.62x54R Belt T</szItemName>
+		<szLongItemName>7.62x54R Belt, Tracer</szLongItemName>
+		<szItemDesc>200 round belt of 7.62x54R tracer rounds aid accurate burst fire.</szItemDesc>
+		<szBRName>7.62x54R Belt Tracer</szBRName>
+		<szBRDesc>Adjusting automatic fire is an easy task with tracer ammo. 200 round belt of tracer ammo.</szBRDesc>
 		<usItemClass>1024</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
 		<ubClassIndex>454</ubClassIndex>
@@ -29297,10 +29297,10 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>938</uiIndex>
-		<szItemName>7.62x54R Box M</szItemName>
-		<szLongItemName>7.62x54R Box Match</szLongItemName>
-		<szItemDesc>200 round box of 7.62x54 sniper ammo.</szItemDesc>
-		<szBRName>7.62x54R Box Match</szBRName>
+		<szItemName>7.62x54R Belt M</szItemName>
+		<szLongItemName>7.62x54R Belt Match</szLongItemName>
+		<szItemDesc>200 round belt of 7.62x54R match ammo.</szItemDesc>
+		<szBRName>7.62x54R Belt Match</szBRName>
 		<szBRDesc>Not available at BR</szBRDesc>
 		<usItemClass>1024</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
@@ -37993,6 +37993,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
@@ -38017,6 +38018,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
@@ -38042,6 +38044,7 @@
 		<RangeBonus>120</RangeBonus>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38067,6 +38070,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38095,6 +38099,7 @@
 		<BulletSpeedBonus>-10</BulletSpeedBonus>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38121,6 +38126,7 @@
 		<PercentNoiseReduction>40</PercentNoiseReduction>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38147,6 +38153,7 @@
 		<PercentNoiseReduction>40</PercentNoiseReduction>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38172,6 +38179,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
@@ -38196,6 +38204,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
@@ -38221,6 +38230,7 @@
 		<RangeBonus>120</RangeBonus>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38246,6 +38256,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38274,6 +38285,7 @@
 		<BulletSpeedBonus>-10</BulletSpeedBonus>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38300,6 +38312,7 @@
 		<PercentNoiseReduction>40</PercentNoiseReduction>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -38326,6 +38339,7 @@
 		<PercentNoiseReduction>40</PercentNoiseReduction>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -39280,6 +39294,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -39305,6 +39320,7 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -40366,6 +40382,7 @@
 		<RangeBonus>120</RangeBonus>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Ammobelt>1</Ammobelt>
 		<TwoHanded>1</TwoHanded>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -44919,7 +44936,7 @@
 		<uiIndex>1477</uiIndex>
 		<szItemName>7.62x54R Box AP</szItemName>
 		<szLongItemName>7.62x54R Box, AP</szLongItemName>
-		<szItemDesc>Long range penetrating power, for the 7.62x54R chambered weapon in your collection.</szItemDesc>
+		<szItemDesc>Long range penetrating power, for the 7.62x54R chambered weapon in your collection. This box contains 50 rounds.</szItemDesc>
 		<szBRName>7.62x54R Box AP</szBRName>
 		<szBRDesc>Long range penetrating power, for the 7.62x54R chambered weapon in your collection. This box contains 50 rounds.</szBRDesc>
 		<usItemClass>1024</usItemClass>
@@ -44933,7 +44950,6 @@
 		<ubCoolness>5</ubCoolness>
 		<BR_NewInventory>3</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
-		<Ammobelt>1</Ammobelt>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<BigGunList>1</BigGunList>
@@ -44945,9 +44961,9 @@
 		<uiIndex>1478</uiIndex>
 		<szItemName>7.62x54R Box T</szItemName>
 		<szLongItemName>7.62x54R Box, Tracer</szLongItemName>
-		<szItemDesc>Ranging and shot placement are easy with these rounds of 7.62 Russian tracer. Tracer ammo adds a bonus to hit in burst and full-auto modes.</szItemDesc>
+		<szItemDesc>Ranging and shot placement are easy with these rounds of 7.62 Russian tracer. Tracer ammo adds a bonus to hit in burst and full-auto modes. This box contains 50 rounds of tracer ammunition.</szItemDesc>
 		<szBRName>7.62x54R Box Tracer</szBRName>
-		<szBRDesc>Ranging and shot placement are easy with these rounds of 7.62 Russian tracer. Tracer ammo adds a bonus to hit in burst and full-auto modes.</szBRDesc>
+		<szBRDesc>Ranging and shot placement are easy with these 50 rounds of 7.62 Russian tracer. Tracer ammo adds a bonus to hit in burst and full-auto modes.</szBRDesc>
 		<usItemClass>1024</usItemClass>
 		<ubClassIndex>451</ubClassIndex>
 		<ubGraphicType>1</ubGraphicType>
@@ -44962,7 +44978,6 @@
 		<AutoFireToHitBonus>6</AutoFireToHitBonus>
 		<BurstToHitBonus>2</BurstToHitBonus>
 		<BulletSpeedBonus>-10</BulletSpeedBonus>
-		<Ammobelt>1</Ammobelt>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<BigGunList>1</BigGunList>
@@ -44974,7 +44989,7 @@
 		<uiIndex>1479</uiIndex>
 		<szItemName>7.62x54R Box M</szItemName>
 		<szLongItemName>7.62x54R Box, Match</szLongItemName>
-		<szItemDesc>7.62x54R Match ammunition.</szItemDesc>
+		<szItemDesc>7.62x54R Match ammunition, 50 rounds.</szItemDesc>
 		<szBRName>7.62x54R Box Match</szBRName>
 		<szBRDesc>Long range penetrating power for the 7.62x54R chambered weapon in your collection. This box contains 50 rounds of match ammunition.</szBRDesc>
 		<usItemClass>1024</usItemClass>
@@ -44989,7 +45004,6 @@
 		<BR_NewInventory>2</BR_NewInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<RangeBonus>120</RangeBonus>
-		<Ammobelt>1</Ammobelt>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<BigGunList>1</BigGunList>


### PR DESCRIPTION
- boxes of 7.62x54R are no longer considered ammobelt
- renamed 7.62x54R belts to "belt" instead of "box"
- added amount of rounds to belt description, if missing
- crates of 7.62x51, 5.56x45 and 7.62x54R are considered ammobelt
- such crates can be used to externally feed suitable weapons
- since they are to big for vest, can only be done out of merc hand 
- (second merc has them in hand, is close and looking at weaponholder)