### PR TITLE
Harmonize load screen delay

### DIFF
--- a/Data-1.13/Ja2_Options.INI
+++ b/Data-1.13/Ja2_Options.INI
@@ -674,7 +674,7 @@ USE_LOADSCREENHINTS = TRUE
 ; The delay will only be used if USE_LOADSCREENHINTS = TRUE
 ;------------------------------------------------------------------------------------------------------------------------------
 
-ADDITIONAL_DELAY_UNTIL_LOADSCREEN_DISPOSAL = 2
+ADDITIONAL_DELAY_UNTIL_LOADSCREEN_DISPOSAL = 0
 
 ;------------------------------------------------------------------------------------------------------------------------------
 ;New Starting Gear Interface

--- a/Data-UB/AddOns/Data-UB-1.13/Ja2_Options.ini
+++ b/Data-UB/AddOns/Data-UB-1.13/Ja2_Options.ini
@@ -612,7 +612,7 @@ USE_LOADSCREENHINTS = TRUE
 ; The delay will only be used if USE_LOADSCREENHINTS = TRUE
 ;------------------------------------------------------------------------------------------------------------------------------
 
-ADDITIONAL_DELAY_UNTIL_LOADSCREEN_DISPOSAL = 2
+ADDITIONAL_DELAY_UNTIL_LOADSCREEN_DISPOSAL = 0
 
 ;------------------------------------------------------------------------------------------------------------------------------
 ;New Starting Gear Interface


### PR DESCRIPTION
Gameplay hints are shown in the message log after a load so let's not make the player wait for extra time