### PR TITLE
Remove duplicate salary

### DIFF
--- a/Data-UB/AddOns/Data-UB-1.13/TableData/MercProfiles25.xml
+++ b/Data-UB/AddOns/Data-UB-1.13/TableData/MercProfiles25.xml
@@ -6569,9 +6569,6 @@
 		<bHatedNationalityCareLevel>0</bHatedNationalityCareLevel>
 		<bRacist>0</bRacist>
 		<bSexist>0</bSexist>
-		<sSalary>0</sSalary>
-		<uiWeeklySalary>0</uiWeeklySalary>
-		<uiBiWeeklySalary>0</uiBiWeeklySalary>
 		<bMedicalDeposit>0</bMedicalDeposit>
 		<sMedicalDepositAmount>0</sMedicalDepositAmount>
 		<usOptionalGearCost>2530</usOptionalGearCost>


### PR DESCRIPTION
UB Gaston (profile 58) had salary tags duplicated with the latter tags having value 0 making him a free mercenary. A veritable oxymoron!