### PR TITLE
Qol Made choice about climbing with backpack easier

### DIFF
--- a/Data-1.13/Ja2_Options.INI
+++ b/Data-1.13/Ja2_Options.INI
@@ -2067,15 +2067,64 @@ CAN_JUMP_THROUGH_CLOSED_WINDOWS = TRUE
 CAN_CLIMB_ON_WALLS = TRUE
 
 ;------------------------------------------------------------------------------------------------------------------------------
-; MAX_BACKPACK_WEIGHT_TO_CLIMB is the maximum weight a backpack can weigh and still allow you to climb with. 
-; The sBackpackWeightModifier in items.xml can modify that number by either making it harder (positive number modifier) 
-; or easier (negative number modifier). If the sBackpackWeightToClimb is -1 (default) then the option is unused.
+;
+; Set if and how climbing with backpacks is allowed.
+;
+; By weight:
+; ----------
 ; 
-; If USE_GLOBAL_BACKPACK_SETTINGS is TRUE (default), it uses the same rules for all backpacks, while if FALSE checks for 
-; the fAllowClimbing tag in Items.xml, and if that is true you can climb with the backpack.
+; MAX_BACKPACK_WEIGHT_TO_CLIMB is the maximum weight a backpack can weigh and still allow you to climb with.
 ; 
-; Both options can be used at the same time, so you may climb with (for example) a malice backpack that weighs less than 5kg
-; (or 50 hg) but not climb with a radio set.
+; - weight of backpack = <ubWeight> of backpack-item in items.xml
+; - if MAX_BACKPACK_WEIGHT_TO_CLIMB is equal or higher than <ubWeight> = climbing allowed
+; - range 1-100 (10 = 1kg, i.e. TIMS <ubWeight> 35 is 3.5kg in game)
+; - if MAX_BACKPACK_WEIGHT_TO_CLIMB is -1 (default), the option is unused
+;  
+; - The tag <BackpackWeightModifier> at backpack-item in items.xml can modify that number by either 
+;   making it harder (positive number modifier) or easier (negative number modifier)
+; - won't alter the real weight of backpack, just a modifier for checking MAX_BACKPACK_WEIGHT_TO_CLIMB
+; - Example:
+;    If MAX_BACKPACK_WEIGHT_TO_CLIMB = 30 and items <ubWeight> = 35, no climbing allowed. 
+;    But if <BackpackWeightModifier> = -5 would be applied, climbing would be allowed (35-5=30).
+; - if <BackpackWeightModifier> is -1 (default), the modifier is unused
+;
+; By global setting:
+; ------------------
+;
+; If USE_GLOBAL_BACKPACK_SETTINGS is TRUE (default), it uses the same rules for all backpacks
+; 
+; - if TRUE and MAX_BACKPACK_WEIGHT_TO_CLIMB is not set to -1, the weight rules apply to all backpacks
+; - if TRUE and MAX_BACKPACK_WEIGHT_TO_CLIMB is -1, no climbing is allowed for any backpack
+;
+; - if FALSE, checks for tag <AllowClimbing> at backpack-items, and if that is set to 1 (default),
+;   climbing with backpack is allowed, while ignoring settings of MAX_BACKPACK_WEIGHT_TO_CLIMB 
+; 
+; - if FALSE and tag <AllowClimbing> is 0, climbing isn't allowed, 
+;   unless MAX_BACKPACK_WEIGHT_TO_CLIMB is used at the same time, in which case settings from there apply
+;
+; By combining both:
+; ------------------
+;
+; Both options can be used at the same time, allowing for some granular choices.
+;
+; Tl;dr:
+; ------
+;
+; - no climbing with backpacks at all:     MAX_BACKPACK_WEIGHT_TO_CLIMB = -1
+;                                          USE_GLOBAL_BACKPACK_SETTINGS = TRUE
+;
+; - always climb with all backpacks:       MAX_BACKPACK_WEIGHT_TO_CLIMB = -1
+;                                          USE_GLOBAL_BACKPACK_SETTINGS = FALSE
+;
+; - climb only with less heavy backpacks:  MAX_BACKPACK_WEIGHT_TO_CLIMB = 30 (example value)
+;                                          USE_GLOBAL_BACKPACK_SETTINGS = FALSE
+;
+; default:
+; --------
+;
+;  MAX_BACKPACK_WEIGHT_TO_CLIMB = -1
+;  USE_GLOBAL_BACKPACK_SETTINGS = TRUE
+;
 ;------------------------------------------------------------------------------------------------------------------------------
 
 MAX_BACKPACK_WEIGHT_TO_CLIMB = -1

--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -7980,6 +7980,8 @@
 		<Damageable>1</Damageable>
 		<Repairable>1</Repairable>
 		<Metal>1</Metal>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -34110,6 +34112,8 @@
 		<BR_NewInventory>2</BR_NewInventory>
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -34134,6 +34138,8 @@
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<TransportGroupMaxProgress>100</TransportGroupMaxProgress>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -34157,6 +34163,8 @@
 		<BR_NewInventory>2</BR_NewInventory>
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -50723,6 +50731,8 @@
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<StealthBonus>-10</StealthBonus>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -51072,6 +51082,8 @@
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<CamoBonus>5</CamoBonus>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -51121,6 +51133,8 @@
 		<BR_NewInventory>1</BR_NewInventory>
 		<BR_UsedInventory>1</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
@@ -51481,7 +51495,8 @@
 		<BR_UsedInventory>2</BR_UsedInventory>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Sinks>1</Sinks>
-		<Attachment>1</Attachment>
+		<AllowClimbing>1</AllowClimbing>
+		<sBackpackWeightModifier>-1</sBackpackWeightModifier>
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />


### PR DESCRIPTION
Previously that choice required users themself to add tags to items. 

Added those tags, <AllowClimbing> and <BackpackWeightModifier>, to relevant backpack items in items.xml. 

Changed the description in ja2options.ini to reflect that change.