### PR TITLE
Item updates

### DIFF
--- a/Data-1.13/TableData/Items/Drugs.xml
+++ b/Data-1.13/TableData/Items/Drugs.xml
@@ -806,4 +806,39 @@ If <chance> is set, this is the chance that this effect is applied when consumin
 			<chance>3</chance>
 		</DISEASE_EFFECT>
 	</DRUG>
+	<DRUG>
+	    <!-- the Soda we get at vending machines -->
+		<uiIndex>21</uiIndex>
+		<szName>Soda</szName>
+		<!-- BP -->
+		<DRUG_EFFECT>
+			<effect>1</effect>          
+			<duration>4</duration>
+			<size>40</size>
+		</DRUG_EFFECT>
+		<!-- AP -->
+		<DRUG_EFFECT>
+			<effect>2</effect>          
+			<duration>2</duration>
+			<size>2</size>
+		</DRUG_EFFECT>
+		 <!-- AGI -->
+		<DRUG_EFFECT>
+			<effect>6</effect>         
+			<duration>5</duration>
+			<size>2</size>
+		</DRUG_EFFECT>
+		<!-- Nervous -->
+		<DISABILITY_EFFECT>
+			<disability>2</disability>  
+			<duration>6</duration>
+			<chance>40</chance>
+		</DISABILITY_EFFECT>
+		<!-- Chance to help curing (vomiting and diarrhea caused by) Staphylococcus -->
+		<DISEASE_EFFECT>
+			<disease>4</disease>
+			<size>-50</size>
+			<chance>30</chance>
+		</DISEASE_EFFECT>
+	</DRUG>
 </DRUGSLIST>

--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -19833,6 +19833,7 @@
 		<WaterDamages>1</WaterDamages>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Covert>1</Covert>
 		<ShowStatus>1</ShowStatus>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -20578,6 +20579,7 @@
 		<WaterDamages>1</WaterDamages>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Covert>1</Covert>
 		<ShowStatus>1</ShowStatus>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -21148,7 +21150,7 @@
 		<ubCursor>3</ubCursor>
 		<ubGraphicNum>128</ubGraphicNum>
 		<ubWeight>15</ubWeight>
-		<ItemSize>5</ItemSize>
+		<ItemSize>3</ItemSize>
 		<usPrice>700</usPrice>
 		<ubCoolness>3</ubCoolness>
 		<bReliability>5</bReliability>
@@ -21920,7 +21922,7 @@
 		<ubCursor>3</ubCursor>
 		<ubGraphicNum>197</ubGraphicNum>
 		<ubWeight>18</ubWeight>
-		<ItemSize>4</ItemSize>
+		<ItemSize>3</ItemSize>
 		<usPrice>900</usPrice>
 		<ubCoolness>4</ubCoolness>
 		<bReliability>2</bReliability>
@@ -22200,6 +22202,7 @@
 		<WaterDamages>1</WaterDamages>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Covert>1</Covert>
 		<ShowStatus>1</ShowStatus>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -24454,6 +24457,7 @@
 		<Repairable>1</Repairable>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Covert>1</Covert>
 		<ShowStatus>1</ShowStatus>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -33207,6 +33211,7 @@
 		<Repairable>1</Repairable>
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
+		<Covert>1</Covert>
 		<ShowStatus>1</ShowStatus>
 		<BigGunList>1</BigGunList>
 		<STAND_MODIFIERS />
@@ -48934,6 +48939,7 @@
 		<ubGraphicNum>155</ubGraphicNum>
 		<ubWeight>1</ubWeight>
 		<ubPerPocket>2</ubPerPocket>
+		<ItemSize>18</ItemSize>
 		<usPrice>8</usPrice>
 		<ubCoolness>1</ubCoolness>
 		<BR_NewInventory>6</BR_NewInventory>
@@ -48960,6 +48966,7 @@
 		<ubGraphicNum>156</ubGraphicNum>
 		<ubWeight>1</ubWeight>
 		<ubPerPocket>8</ubPerPocket>
+		<ItemSize>12</ItemSize>
 		<usPrice>2</usPrice>
 		<ubCoolness>1</ubCoolness>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
@@ -52024,9 +52031,10 @@
 		<ItemSize>18</ItemSize>
 		<usPrice>3</usPrice>
 		<ubCoolness>1</ubCoolness>
+		<DrugType>21</DrugType>
 		<FoodType>40</FoodType>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
-		<usPortionSize>100</usPortionSize>
+		<usPortionSize>100</usPortionSize>		
 		<Soda>1</Soda>
 		<Metal>1</Metal>
 		<STAND_MODIFIERS />

--- a/Data-1.13/TableData/Items/Pockets.xml
+++ b/Data-1.13/TableData/Items/Pockets.xml
@@ -451,8 +451,7 @@
 		<pType>2</pType>
 		<pRestriction>2</pRestriction>
 		<pVolume>20</pVolume>
-		<ItemCapacityPerSize4>1</ItemCapacityPerSize4>
-		<ItemCapacityPerSize5>1</ItemCapacityPerSize5>
+		<ItemCapacityPerSize3>1</ItemCapacityPerSize3>
 	</POCKET>
 	<POCKET>
 		<pIndex>26</pIndex>


### PR DESCRIPTION
items.xml
- Soda (from vending machine), added drugtype
- Sawed-off and Super Shorty, item size changed to fit SG Holster
- Pepper spray and canister, item size added, prior didn't have one
- Added covert-tag to a few pistols with matching description text 

drugs.xml
- added drugtype for Soda (vending machine) 

pockets.xml
- changed pocket 25 for SG Holster
- lower itemsize allowed to restrict to short shotguns