### PR TITLE
More products for the Drassen Factory + item name changes

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -8427,7 +8427,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>284</uiIndex>
-		<szItemName>BDU Jacket</szItemName>
+		<szItemName>W-BDU Jacket</szItemName>
 		<szLongItemName>Woodland BDU Jacket</szLongItemName>
 		<szItemDesc>A Battle Dress Uniform jacket, in woodland camouflage. Fits under most body armor vests.</szItemDesc>
 		<szBRName>Woodland BDU Jacket</szBRName>
@@ -8464,7 +8464,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>285</uiIndex>
-		<szItemName>Hat</szItemName>
+		<szItemName>Boonie Hat</szItemName>
 		<szLongItemName>Boonie Hat</szLongItemName>
 		<szItemDesc>A nice boonie hat to wear when your helmet gets too hot. Provides limited camouflage.</szItemDesc>
 		<szBRName>Boonie Hat</szBRName>
@@ -52780,7 +52780,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1766</uiIndex>
-		<szItemName>BDU Pants</szItemName>
+		<szItemName>W-BDU Pants</szItemName>
 		<szLongItemName>Woodland BDU Pants</szLongItemName>
 		<szItemDesc>These Battle Dress Uniform pants in woodland camouflage will protect your lower limbs from minor cuts and bruises, and will fit under most leg armor systems.</szItemDesc>
 		<szBRName>Woodland BDU Pants</szBRName>
@@ -52813,7 +52813,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1767</uiIndex>
-		<szItemName>BDU Pants</szItemName>
+		<szItemName>D-BDU Pants</szItemName>
 		<szLongItemName>Desert BDU Pants</szLongItemName>
 		<szItemDesc>These Battle Dress Uniform pants in desert camouflage will protect your lower limbs from minor cuts and bruises, and will fit under most leg armor systems.</szItemDesc>
 		<szBRName>Desert BDU Pants</szBRName>
@@ -52846,7 +52846,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1768</uiIndex>
-		<szItemName>BDU Pants</szItemName>
+		<szItemName>U-BDU Pants</szItemName>
 		<szLongItemName>Urban BDU Pants</szLongItemName>
 		<szItemDesc>These Battle Dress Uniform pants in urban camouflage will protect your lower limbs from minor cuts and bruises, and will fit under most leg armor systems.</szItemDesc>
 		<szBRName>Urban BDU Pants</szBRName>
@@ -52878,7 +52878,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1769</uiIndex>
-		<szItemName>BDU Jacket</szItemName>
+		<szItemName>D-BDU Jacket</szItemName>
 		<szLongItemName>Desert BDU Jacket</szLongItemName>
 		<szItemDesc>A Battle Dress Uniform jacket, in desert camouflage. Fits snugly under most body armor vests.</szItemDesc>
 		<szBRName>Desert BDU Jacket</szBRName>
@@ -52915,7 +52915,7 @@
 	</ITEM>
 	<ITEM>
 		<uiIndex>1770</uiIndex>
-		<szItemName>BDU Jacket</szItemName>
+		<szItemName>U-BDU Jacket</szItemName>
 		<szLongItemName>Urban BDU Jacket</szLongItemName>
 		<szItemDesc>A Battle Dress Uniform jacket, in urban camouflage. Fits snugly under most body armor vests.</szItemDesc>
 		<szBRName>Urban BDU Jacket</szBRName>

--- a/Data-1.13/TableData/Map/FacilityTypes.xml
+++ b/Data-1.13/TableData/Map/FacilityTypes.xml
@@ -600,19 +600,30 @@
 			<usItemToCreate>195</usItemToCreate>
 			<sMinutesRequired>120</sMinutesRequired>
 			<sGridNo_Creation>12759</sGridNo_Creation>
-			<sHourlyCost>7</sHourlyCost>			
+			<sHourlyCost>7</sHourlyCost>
 			<usOptional_LoyaltyRequired>15</usOptional_LoyaltyRequired>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
 		</PRODUCTIONLINE>
 		<PRODUCTIONLINE>
-			<!-- create green T-Shirt from string + rag (2x) -->
-			<usItemToCreate>1609</usItemToCreate>
+			<!-- create White Shirt (Civ Disguise) from string + rag (2x) -->
+			<usItemToCreate>1612</usItemToCreate>
 			<sMinutesRequired>120</sMinutesRequired>
 			<sGridNo_Creation>12917</sGridNo_Creation>
-			<sHourlyCost>7</sHourlyCost>			
-			<usOptional_LoyaltyRequired>15</usOptional_LoyaltyRequired>
+			<sHourlyCost>20</sHourlyCost>
+			<usOptional_LoyaltyRequired>40</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+		</PRODUCTIONLINE>
+		<PRODUCTIONLINE>
+			<!-- create Blue Jeans (Civ Disguise) from string + rag (2x) -->
+			<usItemToCreate>1619</usItemToCreate>
+			<sMinutesRequired>120</sMinutesRequired>
+			<sGridNo_Creation>12917</sGridNo_Creation>
+			<sHourlyCost>20</sHourlyCost>
+			<usOptional_LoyaltyRequired>40</usOptional_LoyaltyRequired>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
@@ -621,38 +632,120 @@
 			<!-- we have to build an upgrade before we can create uniforms -->
 			<szProductionName>Upgrade</szProductionName>
 			<sMinutesRequired>181</sMinutesRequired>
-			<sHourlyCost>100</sHourlyCost>			
-			<usOptional_LoyaltyRequired>15</usOptional_LoyaltyRequired>
+			<sHourlyCost>100</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
 		</PRODUCTIONLINE>
 		<PRODUCTIONLINE>
-			<!-- create Field uniform from string (3x) + rag (3x) -->
+			<!-- create Woodland Boonie Hat from string (2x) + rag (2x) + WL camo kit -->
+			<szAdditionalRequirementTips> - Uniform requires upgrade</szAdditionalRequirementTips>
+			<usItemToCreate>285</usItemToCreate>
+			<sMinutesRequired>200</sMinutesRequired>
+			<sGridNo_Creation>11316</sGridNo_Creation>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>205</usOptional_ItemUsedUp>
+		</PRODUCTIONLINE>
+		<PRODUCTIONLINE>
+			<!-- create Woodland BDU Jacket from string (3x) + rag (3x) + WL camo kit -->
 			<szAdditionalRequirementTips> - Uniform requires upgrade</szAdditionalRequirementTips>
 			<usItemToCreate>284</usItemToCreate>
 			<sMinutesRequired>300</sMinutesRequired>
 			<sGridNo_Creation>11316</sGridNo_Creation>
-			<sHourlyCost>25</sHourlyCost>			
-			<usOptional_LoyaltyRequired>30</usOptional_LoyaltyRequired>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>205</usOptional_ItemUsedUp>
 		</PRODUCTIONLINE>
 		<PRODUCTIONLINE>
-			<!-- create Field uniform from green T-Shirt, string (2x) + rag -->
-			<usItemToCreate>284</usItemToCreate>
-			<sMinutesRequired>180</sMinutesRequired>
+			<!-- create Woodland BDU Pants from string (3x) + rag (3x) + WL camo kit -->
+			<szAdditionalRequirementTips> - Uniform requires upgrade</szAdditionalRequirementTips>
+			<usItemToCreate>1766</usItemToCreate>
+			<sMinutesRequired>300</sMinutesRequired>
 			<sGridNo_Creation>11316</sGridNo_Creation>
-			<sHourlyCost>37</sHourlyCost>			
-			<usOptional_LoyaltyRequired>30</usOptional_LoyaltyRequired>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
 			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
-			<usOptional_ItemUsedUp>1609</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>205</usOptional_ItemUsedUp>
+		</PRODUCTIONLINE>
+		<PRODUCTIONLINE>
+			<!-- create Desert BDU Jacket from string (3x) + rag (3x) + Desert camo kit -->
+			<szAdditionalRequirementTips> - Uniform requires upgrade</szAdditionalRequirementTips>
+			<usItemToCreate>1769</usItemToCreate>
+			<sMinutesRequired>300</sMinutesRequired>
+			<sGridNo_Creation>11316</sGridNo_Creation>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1028</usOptional_ItemUsedUp>
+		</PRODUCTIONLINE>
+		<PRODUCTIONLINE>
+			<!-- create Desert BDU Pants from string (3x) + rag (3x) + Desert camo kit -->
+			<usItemToCreate>1767</usItemToCreate>
+			<sMinutesRequired>300</sMinutesRequired>
+			<sGridNo_Creation>11316</sGridNo_Creation>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1028</usOptional_ItemUsedUp>
+		</PRODUCTIONLINE>
+		<PRODUCTIONLINE>
+			<!-- create Urban BDU Jacket from string (3x) + rag (3x) + Urban camo kit -->
+			<szAdditionalRequirementTips> - Uniform requires upgrade</szAdditionalRequirementTips>
+			<usItemToCreate>1770</usItemToCreate>
+			<sMinutesRequired>300</sMinutesRequired>
+			<sGridNo_Creation>11316</sGridNo_Creation>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1027</usOptional_ItemUsedUp>
+		</PRODUCTIONLINE>
+		<PRODUCTIONLINE>
+			<!-- create Urban BDU Pants from string (3x) + rag (3x) + Urban camo kit -->
+			<szAdditionalRequirementTips> - Uniform requires upgrade</szAdditionalRequirementTips>
+			<usItemToCreate>1768</usItemToCreate>
+			<sMinutesRequired>300</sMinutesRequired>
+			<sGridNo_Creation>11316</sGridNo_Creation>
+			<sHourlyCost>25</sHourlyCost>
+			<usOptional_LoyaltyRequired>80</usOptional_LoyaltyRequired>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>311</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1022</usOptional_ItemUsedUp>
+			<usOptional_ItemUsedUp>1027</usOptional_ItemUsedUp>
 		</PRODUCTIONLINE>
 	</FACILITYTYPE>
-	
+
 	<FACILITYTYPE>
 		<ubIndex>24</ubIndex>
 		<szFacilityName>Hicks Farm</szFacilityName>


### PR DESCRIPTION
To expand on the factory in Drassen (C13) BDU jackets + pants are made available for production.
The Boonie Hat was also added as it seemed to fit right in.
Another products are jeans and a shirt to create a civilian disguise for covert operations.

As suggested all camo clothing require an appropriate camo kit to "dye" them.


Item names were also changed as `szItemName` is displayed in the factory screen
The introduced letters have the following meanings
W-Woodland
D-Desert
U-Urban