### PR TITLE
Some items meant for OAS now excluded when not using that

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -3975,6 +3975,7 @@
 		<ubGraphicNum>563</ubGraphicNum>
 		<ubWeight>11</ubWeight>
 		<ItemSize>99</ItemSize>
+		<AttachmentSystem>1</AttachmentSystem>
 		<usPrice>1500</usPrice>
 		<ubCoolness>2</ubCoolness>
 		<bRepairEase>3</bRepairEase>
@@ -33169,6 +33170,7 @@
 		<ubWeight>4</ubWeight>
 		<ubPerPocket>1</ubPerPocket>
 		<ItemSize>99</ItemSize>
+		<AttachmentSystem>1</AttachmentSystem>
 		<usPrice>340</usPrice>
 		<ubCoolness>2</ubCoolness>
 		<bRepairEase>2</bRepairEase>


### PR DESCRIPTION
A.L.I.C.E. backpack
First Response KIt
gave tag AttachmentSystem and set it to 1 (OAS only) with this they won't show without using OAS
there are probably more that should get it, but gotta start somewhere