### PR TITLE
Adding a separate attachment slot for batteries

### DIFF
--- a/Data-1.13/TableData/Items/AttachmentSlots.xml
+++ b/Data-1.13/TableData/Items/AttachmentSlots.xml
@@ -682,4 +682,15 @@
 		<fBigSlot>1</fBigSlot>
 		<ubPocketMapping>12</ubPocketMapping>
 	</ATTACHMENTSLOT>
+	<ATTACHMENTSLOT>
+		<uiSlotIndex>62</uiSlotIndex>
+		<szSlotName>Batteries</szSlotName>
+		<nasAttachmentClass>16384</nasAttachmentClass>
+		<nasLayoutClass>1</nasLayoutClass>
+		<usDescPanelPosX>138</usDescPanelPosX>
+		<usDescPanelPosY>148</usDescPanelPosY>
+		<fMultiShot>0</fMultiShot>
+		<fBigSlot>0</fBigSlot>
+		<ubPocketMapping>0</ubPocketMapping>
+	</ATTACHMENTSLOT>	
 </ATTACHMENTSLOTLIST>

--- a/Data-1.13/TableData/Items/Attachments.xml
+++ b/Data-1.13/TableData/Items/Attachments.xml
@@ -11088,11 +11088,6 @@
 	</ATTACHMENT>
 	<ATTACHMENT>
 		<attachmentIndex>322</attachmentIndex>
-		<itemIndex>324</itemIndex>
-		<APCost>20</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>322</attachmentIndex>
 		<itemIndex>865</itemIndex>
 		<APCost>8</APCost>
 	</ATTACHMENT>
@@ -11135,11 +11130,6 @@
 		<attachmentIndex>322</attachmentIndex>
 		<itemIndex>873</itemIndex>
 		<APCost>8</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>322</attachmentIndex>
-		<itemIndex>950</itemIndex>
-		<APCost>20</APCost>
 	</ATTACHMENT>
 	<ATTACHMENT>
 		<attachmentIndex>322</attachmentIndex>
@@ -11235,26 +11225,6 @@
 		<attachmentIndex>322</attachmentIndex>
 		<itemIndex>1169</itemIndex>
 		<APCost>8</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>322</attachmentIndex>
-		<itemIndex>1626</itemIndex>
-		<APCost>20</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>322</attachmentIndex>
-		<itemIndex>1635</itemIndex>
-		<APCost>20</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>322</attachmentIndex>
-		<itemIndex>1636</itemIndex>
-		<APCost>20</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>322</attachmentIndex>
-		<itemIndex>1637</itemIndex>
-		<APCost>20</APCost>
 	</ATTACHMENT>
 	<ATTACHMENT>
 		<attachmentIndex>592</attachmentIndex>
@@ -22185,11 +22155,6 @@
 	<ATTACHMENT>
 		<attachmentIndex>1009</attachmentIndex>
 		<itemIndex>899</itemIndex>
-		<APCost>20</APCost>
-	</ATTACHMENT>
-	<ATTACHMENT>
-		<attachmentIndex>1010</attachmentIndex>
-		<itemIndex>1076</itemIndex>
 		<APCost>20</APCost>
 	</ATTACHMENT>
 	<ATTACHMENT>

--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -9555,7 +9555,8 @@
 		<szBRName>Batteries</szBRName>
 		<szBRDesc>Not for sale through BR.</szBRDesc>
 		<usItemClass>268435456</usItemClass>
-		<nasAttachmentClass>1</nasAttachmentClass>
+		<nasAttachmentClass>16384</nasAttachmentClass>
+		<AttachmentPoint>16</AttachmentPoint>			
 		<ubGraphicType>2</ubGraphicType>
 		<ubGraphicNum>26</ubGraphicNum>
 		<ubWeight>1</ubWeight>
@@ -9565,6 +9566,7 @@
 		<ubCoolness>1</ubCoolness>
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Damageable>1</Damageable>
+		<WaterDamages>1</WaterDamages>		
 		<Attachment>1</Attachment>
 		<Batteries>1</Batteries>
 		<STAND_MODIFIERS />
@@ -9602,6 +9604,7 @@
 		<szBRDesc>Not for sale through BR.</szBRDesc>
 		<usItemClass>268435456</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
+		<AvailableAttachmentPoint>16</AvailableAttachmentPoint>			
 		<ubCursor>17</ubCursor>
 		<ubGraphicType>1</ubGraphicType>
 		<ubGraphicNum>125</ubGraphicNum>
@@ -9612,7 +9615,9 @@
 		<usOverheatingCooldownFactor>100</usOverheatingCooldownFactor>
 		<Damageable>1</Damageable>
 		<Repairable>1</Repairable>
+		<WaterDamages>1</WaterDamages>			
 		<Metal>1</Metal>
+		<Sinks>1</Sinks>		
 		<NotBuyable>1</NotBuyable>
 		<Electronic>1</Electronic>
 		<NeedsBatteries>1</NeedsBatteries>
@@ -29666,12 +29671,13 @@
 		<uiIndex>950</uiIndex>
 		<szItemName>LAM-Flashlight</szItemName>
 		<szLongItemName>Rifle LAM-Flashlight Combo</szLongItemName>
-		<szItemDesc>This laser aiming module and tactical flashlight combination is meant to fit on modern rifle rail interface systems.</szItemDesc>
+		<szItemDesc>This laser aiming module and tactical flashlight combination is meant to fit on modern rifle rail interface systems. Flashlight is currently OFF.</szItemDesc>
 		<szBRName>Rifle LAM-Flashlight</szBRName>
 		<szBRDesc>This laser aiming module and tactical flashlight combination is meant to fit on modern rifle rail interface systems.</szBRDesc>
 		<usItemClass>268435456</usItemClass>
 		<AttachmentClass>4</AttachmentClass>
 		<nasAttachmentClass>4</nasAttachmentClass>
+		<AvailableAttachmentPoint>16</AvailableAttachmentPoint>			
 		<ubGraphicNum>341</ubGraphicNum>
 		<ubWeight>4</ubWeight>
 		<ubPerPocket>2</ubPerPocket>
@@ -29694,9 +29700,11 @@
 		<StealthBonus>-15</StealthBonus>
 		<TransportGroupMinProgress>30</TransportGroupMinProgress>
 		<TransportGroupMaxProgress>100</TransportGroupMaxProgress>
-		<Damageable>1</Damageable>
+		<Damageable>1</Damageable>		
 		<Repairable>1</Repairable>
+		<WaterDamages>1</WaterDamages>		
 		<Metal>1</Metal>
+		<Sinks>1</Sinks>		
 		<Attachment>1</Attachment>
 		<BigGunList>1</BigGunList>
 		<Electronic>1</Electronic>
@@ -48894,9 +48902,10 @@
 		<szLongItemName>Stun Gun</szLongItemName>
 		<szItemDesc>If used correctly, this stun gun will hit anyone it touches with over 2 million volts. In case you find yourself in need of a drooling, helpless victim.</szItemDesc>
 		<szBRName>Stun Gun</szBRName>
-		<szBRDesc>At 2 million volts, this baby will leave even the sturdiest men twitching helplessly on the floor. Batteries not included!</szBRDesc>
+		<szBRDesc>At 2 million volts, this baby will leave even the sturdiest men twitching helplessly on the floor. Batteries included!</szBRDesc>
 		<usItemClass>128</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
+		<AvailableAttachmentPoint>16</AvailableAttachmentPoint>			
 		<ubClassIndex>49</ubClassIndex>
 		<ubCursor>2</ubCursor>
 		<ubGraphicType>2</ubGraphicType>
@@ -48916,6 +48925,7 @@
 		<Taser>1</Taser>
 		<Damageable>1</Damageable>
 		<Repairable>1</Repairable>
+		<WaterDamages>1</WaterDamages>		
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>
@@ -49142,12 +49152,13 @@
 		<uiIndex>1635</uiIndex>
 		<szItemName>LAM-Flashlight</szItemName>
 		<szLongItemName>Rifle LAM-Flashlight Combo</szLongItemName>
-		<szItemDesc>This laser aiming module and tactical flashlight combination is meant to fit on modern rifle rail interface systems. Flashlight is ON.</szItemDesc>
+		<szItemDesc>This laser aiming module and tactical flashlight combination is meant to fit on modern rifle rail interface systems. Flashlight is currently ON.</szItemDesc>
 		<szBRName>Rifle LAM-Flashlight</szBRName>
 		<szBRDesc>Not for sale through BR.</szBRDesc>
 		<usItemClass>268435456</usItemClass>
 		<AttachmentClass>4</AttachmentClass>
 		<nasAttachmentClass>4</nasAttachmentClass>
+		<AvailableAttachmentPoint>16</AvailableAttachmentPoint>				
 		<ubGraphicNum>341</ubGraphicNum>
 		<ubWeight>4</ubWeight>
 		<ubPerPocket>2</ubPerPocket>
@@ -49171,8 +49182,13 @@
 		<TransportGroupMaxProgress>100</TransportGroupMaxProgress>
 		<Damageable>1</Damageable>
 		<Repairable>1</Repairable>
+		<WaterDamages>1</WaterDamages>		
 		<Metal>1</Metal>
+		<Sinks>1</Sinks>
 		<Attachment>1</Attachment>
+		<HiddenAttachment>1</HiddenAttachment>
+		<NotBuyable>1</NotBuyable>
+		<NotInEditor>1</NotInEditor>		
 		<BigGunList>1</BigGunList>
 		<Electronic>1</Electronic>
 		<NeedsBatteries>1</NeedsBatteries>
@@ -49184,12 +49200,13 @@
 		<uiIndex>1636</uiIndex>
 		<szItemName>Flashlight</szItemName>
 		<szLongItemName>Flashlight</szLongItemName>
-		<szItemDesc>I am... the light! No wait, that ain't right. I'm just a flashlight. But I'm still useful. If everything else fails, use me to knock people over the head.</szItemDesc>
+		<szItemDesc>I am... the light! No wait, that ain't right. I'm just a flashlight. But I'm still useful. If everything else fails, use me to knock people over the head.Flashlight is currently OFF.</szItemDesc>
 		<szBRName>Flashlight</szBRName>
 		<szBRDesc>Let there be light! Batteries included.</szBRDesc>
 		<usItemClass>128</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
 		<ubClassIndex>1636</ubClassIndex>
+		<AvailableAttachmentPoint>16</AvailableAttachmentPoint>			
 		<ubCursor>2</ubCursor>
 		<ubGraphicType>2</ubGraphicType>
 		<ubGraphicNum>161</ubGraphicNum>
@@ -49207,6 +49224,7 @@
 		<DefaultAttachment>322</DefaultAttachment>
 		<Damageable>1</Damageable>
 		<Repairable>1</Repairable>
+		<WaterDamages>1</WaterDamages>		
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>
@@ -49221,12 +49239,13 @@
 		<uiIndex>1637</uiIndex>
 		<szItemName>Flashlight</szItemName>
 		<szLongItemName>Flashlight</szLongItemName>
-		<szItemDesc>I am... the light! No wait, that ain't right. I'm just a flashlight. But I'm still useful. If everything else fails, use me to knock people over the head. Flashlight is ON.</szItemDesc>
+		<szItemDesc>I am... the light! No wait, that ain't right. I'm just a flashlight. But I'm still useful. If everything else fails, use me to knock people over the head. Flashlight is currently ON.</szItemDesc>
 		<szBRName>Flashlight</szBRName>
 		<szBRDesc>Not for sale through BR.</szBRDesc>
 		<usItemClass>128</usItemClass>
 		<nasLayoutClass>1</nasLayoutClass>
 		<ubClassIndex>1637</ubClassIndex>
+		<AvailableAttachmentPoint>16</AvailableAttachmentPoint>			
 		<ubCursor>2</ubCursor>
 		<ubGraphicType>2</ubGraphicType>
 		<ubGraphicNum>161</ubGraphicNum>
@@ -49243,12 +49262,15 @@
 		<DefaultAttachment>322</DefaultAttachment>
 		<Damageable>1</Damageable>
 		<Repairable>1</Repairable>
+		<WaterDamages>1</WaterDamages>		
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>
 		<Electronic>1</Electronic>
 		<BrassKnuckles>1</BrassKnuckles>
 		<NeedsBatteries>1</NeedsBatteries>
+		<NotBuyable>1</NotBuyable>
+		<NotInEditor>1</NotInEditor>		
 		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />

--- a/Data-1.13/TableData/Lookup/AttachmentPoint.xml
+++ b/Data-1.13/TableData/Lookup/AttachmentPoint.xml
@@ -28,4 +28,9 @@
 		<id>8</id>
 		<name>Surgical Mask and Gloves</name>
 	</AttachmentPoint>
+	</AttachmentPoint>
+		<AttachmentPoint>
+		<id>16</id>
+		<name>Batteries</name>
+	</AttachmentPoint>	
 </JA2Data>

--- a/Data-1.13/TableData/Lookup/NasAttachmentClass.xml
+++ b/Data-1.13/TableData/Lookup/NasAttachmentClass.xml
@@ -60,4 +60,8 @@
 		<id>8192</id>
 		<name>MOLLE Medium</name>
 	</NasAttachmentClass>
+    <NasAttachmentClass>
+		<id>16384</id>
+		<name>Batteries</name>
+	</NasAttachmentClass>		
 </JA2Data>


### PR DESCRIPTION
Previously, a glitch could happen when one attachment used batteries while weapon did have a stock attachment as well. 
Now batteries have their own attachment slot, no longer in conflict with slot for weapon stocks