### PR TITLE
fixed .50 BMG CRATE

### DIFF
--- a/Data-1.13/TableData/Items/Magazines.xml
+++ b/Data-1.13/TableData/Items/Magazines.xml
@@ -2461,14 +2461,14 @@
 		<uiIndex>351</uiIndex>
 		<ubCalibre>17</ubCalibre>
 		<ubMagSize>300</ubMagSize>
-		<ubAmmoType>3</ubAmmoType>
+		<ubAmmoType>31</ubAmmoType>
 		<ubMagType>3</ubMagType>
 	</MAGAZINE>
 	<MAGAZINE>
 		<uiIndex>352</uiIndex>
 		<ubCalibre>18</ubCalibre>
 		<ubMagSize>20</ubMagSize>
-		<ubAmmoType>31</ubAmmoType>
+		<ubAmmoType>3</ubAmmoType>
 		<ubMagType>0</ubMagType>
 	</MAGAZINE>
 	<MAGAZINE>


### PR DESCRIPTION
- .50 bmg couldn't be merged into crates due to wrong ammo type (copy paste error?)
(not sure why github deleted & replaced very last line, should be fine anyway)