### PR TITLE
Adjusted stand modifiers for HK MP5KA4

### DIFF
--- a/Data-1.13/TableData/Items/Items.xml
+++ b/Data-1.13/TableData/Items/Items.xml
@@ -583,11 +583,7 @@
 		<Metal>1</Metal>
 		<Sinks>1</Sinks>
 		<ShowStatus>1</ShowStatus>
-		<STAND_MODIFIERS>
-			<PercentHandling>-10</PercentHandling>
-			<PercentMaxCounterForce>30</PercentMaxCounterForce>
-			<PercentCounterForceAccuracy>30</PercentCounterForceAccuracy>
-		</STAND_MODIFIERS>
+		<STAND_MODIFIERS />
 		<CROUCH_MODIFIERS />
 		<PRONE_MODIFIERS />
 	</ITEM>


### PR DESCRIPTION
due to the newly added attchemt of a foregrip, the stand modifiers of that weapon in items.xml are no longer needed. Removed them so that they don't add up to the ones provided by foregrip, would be to much otherwise.