### PR TITLE
Fix lua hourly update script

### DIFF
--- a/Data-1.13/Scripts/HourlyUpdate.lua
+++ b/Data-1.13/Scripts/HourlyUpdate.lua
@@ -10,14 +10,14 @@ local p = 0
 
 function HourlyQuestUpdate()
 
-	if (cHour >= 4 or cHour < 20) then
+	if (cHour == 4) then
 		SetFactFalse( Facts.FACT_BROTHEL_OPEN )
-	else
+	elseif (cHour == 20) then
 		SetFactTrue( Facts.FACT_BROTHEL_OPEN )
 	end
 
 	-- Bar/night club
-	if ( cHour >= 15 or cHour < 2) then
+	if ( cHour == 15 ) then
 	
 		SetFactTrue( Facts.FACT_CLUB_OPEN )
 		SetFactFalse( Facts.FACT_PAST_CLUB_CLOSING_AND_PLAYER_WARNED )
@@ -34,24 +34,22 @@ function HourlyQuestUpdate()
 		if ( gfBoxersResting == true ) then
 			
 			-- Done resting now!
-			gfBoxersResting = false
-			gubBoxersRests = gubBoxersRests + 1
+			SetgfBoxersResting(false)
+			SetgubBoxersRests(gubBoxersRests + 1)
 			
-			p = gubBoxingMatchesWon / 3
-			
-		elseif ( p > gubBoxersRests ) then
+		elseif ( gubBoxingMatchesWon / 3 > gubBoxersRests ) then
 			-- Time for the boxers to rest!
-			gfBoxersResting = true
+			SetgfBoxersResting(true)
 		end
 
-	else
+	elseif ( cHour == 2 ) then
 		SetFactFalse( Facts.FACT_CLUB_OPEN )
 	end
 
 	-- Museum
-	if ( cHour >= 9 or cHour < 18 ) then
+	if ( cHour == 9 ) then
 		SetFactTrue( Facts.FACT_MUSEUM_OPEN )
-	else
+	elseif ( cHour == 18 ) then
 		SetFactFalse( Facts.FACT_MUSEUM_OPEN )
 	end
 


### PR DESCRIPTION
Use lua setters instead of reassigning the global so it actually does something 

Reverted the time conditionals change that was made during lua externalization so that it only updates on the opening/closing hours instead of every hour in between. Why was this change necessary to begin with? It also makes it so it resets all the boxing variables every hour instead of daily (not that these variables even worked properly before the setter fix here anyway)

In practice, this fixes a few things so they work as originally intended: 
- Boxers will actually rest for 1 day after every 3 fights as originally intended 
- After every rest, boxers will get progressively stronger and harder to beat as originally intended

There is one issue with this fix though, for players who install this change mid campaign, the boxers might rest every other day for a while even if no fights take place because they need to rest 1 day for every 3 fights they've ever fought in. For players who start a new game everything should work properly
